### PR TITLE
Add support for controlling output HTML element

### DIFF
--- a/src/Docs/View.fs
+++ b/src/Docs/View.fs
@@ -9,13 +9,13 @@ open Docs.Router
 let menuPart model =
     let item (t:string) p =
         let isActive =
-            if model.CurrentPage = p then [ helpers.isActive; color.hasBackgroundPrimary ] else []  
-        Bulma.menuItem [
+            if model.CurrentPage = p then [ helpers.isActive; color.hasBackgroundPrimary ] else []
+        Bulma.menuItem.li [
             yield! isActive
             yield prop.text t
             yield prop.href (Router.getHref p)
         ]
-    
+
     Bulma.menu [
         Bulma.menuLabel "Feliz.Bulma"
         Bulma.menuList [
@@ -72,8 +72,8 @@ let contentPart model dispatch =
     | PopoverInstallation -> Views.Popover.installation
     | PageLoaderOverview -> Views.PageLoader.overview model dispatch
     | PageLoaderInstallation -> Views.PageLoader.installation
-    
-    
+
+
 let view (model : Model) (dispatch : Msg -> unit) =
     let render =
         Bulma.container [

--- a/src/Docs/Views.Bulma.fs
+++ b/src/Docs/Views.Bulma.fs
@@ -7,7 +7,7 @@ open Feliz.Bulma.Operators
 
 let overview =
     Html.div [
-        Bulma.title [
+        Bulma.title.h1 [
             Html.text "Feliz.Bulma "
             Html.a [
                 prop.href "https://www.nuget.org/packages/Feliz.Bulma/"
@@ -18,7 +18,7 @@ let overview =
                 ]
             ]
         ]
-        Bulma.subtitle [
+        Bulma.subtitle.h2 [
             Html.text "Bulma UI wrapper for amazing "
             Html.a [ prop.href "https://github.com/Zaid-Ajaj/Feliz"; prop.text "Feliz DSL" ]
         ]
@@ -54,29 +54,29 @@ Bulma.columns [
 """
         ]
         Bulma.content [
-            Bulma.title4 "Features"
+            Bulma.title.h4 "Features"
             Html.ul [
                 Html.li "Fully compatible with Feliz DSL syntax"
                 Html.li "100% API coverage of Bulma UI (v0.8.0)"
                 Html.li [ prop.dangerouslySetInnerHTML "Compatible with <a href='https://github.com/zaid-ajaj/femto'>Femto CLI</a> "]
-                
+
             ]
         ]
     ]
-    
+
 let installation = Shared.installationView "Feliz.Bulma" "bulma"
-    
+
 let apiDescription =
     Html.div [
-        Bulma.title "Feliz.Bulma - API"
+        Bulma.title.h1 "Feliz.Bulma - API"
         Html.hr []
         Bulma.content [
             Html.p [ prop.dangerouslySetInnerHTML "Feliz.Bulma fully covers <a href='https://bulma.io'>Bulma UI</a> in version 0.8.0." ]
         ]
         Bulma.content [
-            Bulma.title4 "Example"
+            Bulma.title.h4 "Example"
             code """open Feliz.Bulma
-            
+
 Bulma.button [
     button.isWarning
     prop.onClick (fun _ -> Fable.Core.JS.eval "alert('Hello Feliz.Bulma')" |> ignore)
@@ -84,7 +84,7 @@ Bulma.button [
 ]
 """
             Html.p "Code above will generate this button:"
-            Bulma.button [
+            Bulma.button.a [
                 button.isWarning
                 prop.onClick (fun _ -> Fable.Core.JS.eval "alert('Hello Feliz.Bulma')" |> ignore)
                 prop.text "Amazing button, ain't it?"
@@ -93,13 +93,13 @@ Bulma.button [
         Bulma.content [
             Html.p [ prop.dangerouslySetInnerHTML "API was designed to be more less 1:1 with Bulma. To see what elements are available in Feliz.Bulma, please check <a href='https://bulma.io/documentation/'>official Bulma documentation</a>." ]
         ]
-        
+
         Bulma.content [
-            Bulma.title "Using Bulma props in Feliz elements"
+            Bulma.title.h1 "Using Bulma props in Feliz elements"
             Html.p [ prop.dangerouslySetInnerHTML "Feliz.Bulma contains some helpers that could be handy to combine with <i>classic</i> Feliz API. Unfortunately this is not supported out of the box - <a href='https://github.com/Zaid-Ajaj/Feliz/issues/128'>see this issue.</a>"]
             Html.p [ prop.dangerouslySetInnerHTML "To allow this behavior, there is new <code>Feliz.Bulma.Operators</code> module with <code>++</code> operator" ]
             code """open Feliz.Bulma.Operators
-            
+
 Html.p [
     text.isUppercase
     ++ text.isItalic
@@ -107,13 +107,29 @@ Html.p [
     prop.text "Hello Feliz"
 ]
 """
-            
+
             Html.p "Code above will work as expected:"
             Html.p [
                 text.isUppercase
                 ++ text.isItalic
                 ++ color.hasTextSuccess
                 prop.text "Hello Feliz"
+            ]
+        ]
+
+        Bulma.card [
+            Bulma.cardHeader [
+                Bulma.cardHeaderTitle "Test"
+            ]
+
+            Bulma.cardContent [
+                prop.text "jkdkzodk"
+            ]
+
+            Bulma.cardFooter [
+                Bulma.cardFooterItem.a "First item"
+                Bulma.cardFooterItem.a "Second item"
+                Bulma.cardFooterItem.a "Third item"
             ]
         ]
     ]

--- a/src/Docs/Views.Calendar.fs
+++ b/src/Docs/Views.Calendar.fs
@@ -19,7 +19,7 @@ let overview =
                 Fable.Core.JS.console.log(x)
             )
         ]
-        
+
     let calcDialog =
         Calendar.calendar [
             prop.id "DialogCal"
@@ -37,9 +37,9 @@ let overview =
                 Fable.Core.JS.console.log(x)
             )
         ]
-       
+
     Html.div [
-        Bulma.title [
+        Bulma.title.h1 [
             Html.text "Feliz.Bulma.Calendar "
             Html.a [
                 prop.href "https://www.nuget.org/packages/Feliz.Bulma.Calendar/"
@@ -50,7 +50,7 @@ let overview =
                 ]
             ]
         ]
-        Bulma.subtitle [
+        Bulma.subtitle.h2 [
             Html.a [ prop.href "https://creativebulma.net/product/calendar/demo"; prop.text "Calendar" ]
             Html.text " extension for Feliz.Bulma"
         ]
@@ -58,7 +58,7 @@ let overview =
         Bulma.content [
             Html.p "This library extends Feliz.Bulma by adding Calendar component"
             code """open Feliz.Bulma.Calendar
-            
+
 Calendar.calendar [
     prop.id "RangeCal"
     calendar.options [
@@ -74,7 +74,7 @@ Calendar.calendar [
             calcRanged
         ]
         Bulma.content [
-            Bulma.title4 "OnValueSelected arguments"
+            Bulma.title.h4 "OnValueSelected arguments"
             Html.p [ prop.dangerouslySetInnerHTML "When value selected or calendar closed, strongly typed <code>SelectedValue</code> is passed to callback function <code>onValueSelected</code>" ]
             code """type TimeValue = { Hours : int; Minutes : int }
 
@@ -93,9 +93,9 @@ type SelectedValue =
     | RangeValue of RangeValue
 """
         ]
-        
+
         Bulma.content [
-            Bulma.title4 "Configuration"
+            Bulma.title.h4 "Configuration"
             Html.p "Calendar component supports various options for configuration"
             code """Calendar.calendar [
     prop.id "DialogCal"

--- a/src/Docs/Views.Checkradio.fs
+++ b/src/Docs/Views.Checkradio.fs
@@ -8,7 +8,7 @@ open Docs.Domain
 
 let overview =
     Html.div [
-        Bulma.title [
+        Bulma.title.h1 [
             Html.text "Feliz.Bulma.Checkradio "
             Html.a [
                 prop.href "https://www.nuget.org/packages/Feliz.Bulma.Checkradio/"
@@ -19,7 +19,7 @@ let overview =
                 ]
             ]
         ]
-        Bulma.subtitle [
+        Bulma.subtitle.h2 [
             Html.a [ prop.href "https://wikiki.github.io/form/checkradio/"; prop.text "Checkradio" ]
             Html.text " extension for Feliz.Bulma"
         ]
@@ -27,7 +27,7 @@ let overview =
         Bulma.content [
             Html.p "This library extends Feliz.Bulma by adding Checkradio component"
             code """open Feliz.Bulma.Checkradio
-            
+
 Bulma.field [
     Checkradio.checkbox [
         prop.id "mycheck"
@@ -38,9 +38,9 @@ Bulma.field [
         prop.text "Check me"
     ]
 ]"""
-            
+
             Html.p "Code above will generate a nice checkbox:"
-            Bulma.field [
+            Bulma.field.div [
                 Checkradio.checkbox [
                     prop.id "mycheck"
                     color.isDanger
@@ -53,7 +53,7 @@ Bulma.field [
         ]
         Bulma.content [
             code """open Feliz.Bulma.Checkradio
-            
+
 Bulma.field [
     Checkradio.radio [ prop.id "myradio1"; prop.name "radio" ]
     Html.label [ prop.htmlFor "myradio1"; prop.text "Option one" ]
@@ -62,18 +62,18 @@ Bulma.field [
 ]
 """
             Html.p "Code above will generate a nice two radio buttons:"
-            Bulma.field [
+            Bulma.field.div [
                 Checkradio.radio [ prop.id "myradio1"; prop.name "radio" ]
                 Html.label [ prop.htmlFor "myradio1"; prop.text "Option one" ]
                 Checkradio.radio [ prop.id "myradio2"; prop.name "radio" ]
                 Html.label [ prop.htmlFor "myradio2"; prop.text "Option two" ]
             ]
-            
+
         ]
         Bulma.content [
             Html.p [ prop.dangerouslySetInnerHTML "All the modifiers mentioned in <a href='https://wikiki.github.io/form/checkradio/'>official documentation</a> will work as expected." ]
             code """open Feliz.Bulma.Checkradio
-            
+
 Bulma.field [
     Checkradio.checkbox [
         prop.id "bigcheck"
@@ -86,9 +86,9 @@ Bulma.field [
         prop.htmlFor "bigcheck"
         prop.text "Large round success checkbox"
     ]
-]                        
+]
 """
-            Bulma.field [
+            Bulma.field.div [
                 Checkradio.checkbox [
                     prop.id "bigcheck"
                     color.isSuccess

--- a/src/Docs/Views.PageLoader.fs
+++ b/src/Docs/Views.PageLoader.fs
@@ -9,7 +9,7 @@ open Docs.Views
 
 let overview (model:Model) dispatch =
     Html.div [
-        Bulma.title [
+        Bulma.title.h1 [
             Html.text "Feliz.Bulma.PageLoader "
             Html.a [
                 prop.href "https://www.nuget.org/packages/Feliz.Bulma.PageLoader/"
@@ -20,7 +20,7 @@ let overview (model:Model) dispatch =
                 ]
             ]
         ]
-        Bulma.subtitle [
+        Bulma.subtitle.h2 [
             Html.a [ prop.href "https://wikiki.github.io/elements/pageloader/"; prop.text "Page Loader" ]
             Html.text " extension for Feliz.Bulma"
         ]
@@ -28,7 +28,7 @@ let overview (model:Model) dispatch =
         Bulma.content [
             Html.p "This library extends Feliz.Bulma by adding Page Loader component"
             code """open Feliz.Bulma.PageLoader
-            
+
 PageLoader.pageLoader [
     pageLoader.isSuccess
     if model.ShowLoader then pageLoader.isActive
@@ -42,7 +42,7 @@ Bulma.button [
     prop.text "Show page loader for 2 seconds"
     prop.onClick (fun _ -> ToggleLoader |> dispatch)
 ]"""
-            
+
             Html.p "Code above will setup Page Loader:"
             PageLoader.pageLoader [
                 pageLoader.isSuccess
@@ -51,13 +51,13 @@ Bulma.button [
                     PageLoader.title "I am loading some awesomeness"
                 ]
             ]
-            
-            Bulma.button [
+
+            Bulma.button.a [
                 button.isSuccess
                 prop.text "Show page loader for 2 seconds"
                 prop.onClick (fun _ -> ToggleLoader |> dispatch)
             ]
-            
+
         ]
     ]
 

--- a/src/Docs/Views.Popover.fs
+++ b/src/Docs/Views.Popover.fs
@@ -8,7 +8,7 @@ open Docs.Domain
 
 let overview =
     Html.div [
-        Bulma.title [
+        Bulma.title.h1 [
             Html.text "Feliz.Bulma.Popover "
             Html.a [
                 prop.href "https://www.nuget.org/packages/Feliz.Bulma.Popover/"
@@ -19,7 +19,7 @@ let overview =
                 ]
             ]
         ]
-        Bulma.subtitle [
+        Bulma.subtitle.h2 [
             Html.a [ prop.href "https://github.com/apnsngr/bulma-popover"; prop.text "Popover" ]
             Html.text " extension for Feliz.Bulma"
         ]
@@ -27,7 +27,7 @@ let overview =
         Bulma.content [
             Html.p "This library extends Feliz.Bulma by adding Popover component"
             code """open Feliz.Bulma.Popover
-            
+
 Popover.popover [
     Bulma.button [
         prop.text "Hover me for popover"
@@ -39,10 +39,10 @@ Popover.popover [
         Html.img [ prop.src "https://pbs.twimg.com/profile_images/518069764510330880/yRNL7yTW_200x200.png" ]
     ]
 ]"""
-            
+
             Html.p "Code above will add popover to button:"
             Popover.popover [
-                Bulma.button [
+                Bulma.button.a [
                     prop.text "Hover me for popover"
                     button.isInfo
                     popover.trigger
@@ -75,7 +75,7 @@ Popover.popover [
             Popover.popover [
                 popover.isRight
                 prop.children [
-                    Bulma.button [
+                    Bulma.button.a [
                         prop.text "Hover me for popover"
                         button.isInfo
                         popover.trigger
@@ -110,7 +110,7 @@ Popover.popover [
                 popover.isActive
                 popover.isBottom
                 prop.children [
-                    Bulma.button [
+                    Bulma.button.a [
                         prop.text "No need to hover me"
                         button.isInfo
                         popover.trigger

--- a/src/Docs/Views.QuickView.fs
+++ b/src/Docs/Views.QuickView.fs
@@ -19,13 +19,13 @@ let overview model dispatch =
                     QuickView.block "Bulma is great"
                 ]
                 QuickView.footer [
-                    Bulma.button "Save"
+                    Bulma.button.a "Save"
                 ]
             ]
         ]
-    
+
     Html.div [
-        Bulma.title [
+        Bulma.title.h1 [
             Html.text "Feliz.Bulma.QuickView "
             Html.a [
                 prop.href "https://www.nuget.org/packages/Feliz.Bulma.QuickView/"
@@ -36,7 +36,7 @@ let overview model dispatch =
                 ]
             ]
         ]
-        Bulma.subtitle [
+        Bulma.subtitle.h2 [
             Html.a [ prop.href "https://wikiki.github.io/components/quickview/"; prop.text "QuickView" ]
             Html.text " extension for Feliz.Bulma"
         ]
@@ -44,7 +44,7 @@ let overview model dispatch =
         Bulma.content [
             Html.p "This library extends Feliz.Bulma by adding QuickView component"
             code """open Feliz.Bulma.QuickView
-            
+
 QuickView.quickview [
     if model.ShowQuickView then yield quickview.isActive
     yield prop.children [
@@ -60,7 +60,7 @@ QuickView.quickview [
         ]
     ]
 ]"""
-            Bulma.button [
+            Bulma.button.a [
                 button.isInfo
                 prop.text (if model.ShowQuickView then "Hide QuickView" else "Show QuickView")
                 prop.onClick (fun _ -> ToggleQuickView |> dispatch)

--- a/src/Docs/Views.Shared.fs
+++ b/src/Docs/Views.Shared.fs
@@ -14,18 +14,18 @@ let code (c:string) =
         prop.className "fsharp"
         prop.text c
     ]
-    
+
 let installationView packageName yarnName =
     Html.div [
-        Bulma.title (sprintf "%s - Installation" packageName)
+        Bulma.title.h1 (sprintf "%s - Installation" packageName)
         Html.hr []
         Bulma.content [
-            Bulma.title4 "Using Femto (recommended)"
+            Bulma.title.h4 "Using Femto (recommended)"
             Html.p [ prop.dangerouslySetInnerHTML "The easiest way is to use <a href='https://github.com/zaid-ajaj/femto'>Femto CLI</a> which will take care of all dependencies including npm libraries." ]
             code (sprintf "femto install %s" packageName)
         ]
         Bulma.content [
-            Bulma.title4 "Manual"
+            Bulma.title.h4 "Manual"
             Html.p "If you want to install this package manually, use usual NuGet package command"
             code (sprintf "Install-Package %s" packageName)
             Html.p "or using Paket"
@@ -33,4 +33,4 @@ let installationView packageName yarnName =
             Html.p "Please don't forget that this library has also dependencies on frontend (css styles), so you need to add it to package.json file using yarn / npm command"
             code (sprintf "yarn add %s" yarnName)
         ]
-    ]    
+    ]

--- a/src/Docs/Views.Tooltip.fs
+++ b/src/Docs/Views.Tooltip.fs
@@ -8,7 +8,7 @@ open Docs.Domain
 
 let overview =
     Html.div [
-        Bulma.title [
+        Bulma.title.h1 [
             Html.text "Feliz.Bulma.Tooltip "
             Html.a [
                 prop.href "https://www.nuget.org/packages/Feliz.Bulma.Tooltip/"
@@ -19,7 +19,7 @@ let overview =
                 ]
             ]
         ]
-        Bulma.subtitle [
+        Bulma.subtitle.h2 [
             Html.a [ prop.href "https://wikiki.github.io/elements/tooltip/"; prop.text "Tooltip" ]
             Html.text " extension for Feliz.Bulma"
         ]
@@ -27,22 +27,22 @@ let overview =
         Bulma.content [
             Html.p "This library extends Feliz.Bulma by adding Tooltip component"
             code """open Feliz.Bulma.Tooltip
-            
+
 Bulma.button [
     tooltip.text "This is tooltip"
     tooltip.hasTooltipWarning
     button.isWarning
     prop.text "Hover me for tooltip"
 ]"""
-            
+
             Html.p "Code above will add tooltip to button:"
-            Bulma.button [
+            Bulma.button.a [
                 tooltip.text "This is tooltip"
                 tooltip.hasTooltipWarning
                 button.isWarning
                 prop.text "Hover me for tooltip"
             ]
-            
+
         ]
     ]
 

--- a/src/Feliz.Bulma.Checkradio/Checkradio.fs
+++ b/src/Feliz.Bulma.Checkradio/Checkradio.fs
@@ -1,14 +1,13 @@
 ﻿namespace Feliz.Bulma.Checkradio
 
+open Feliz
 open Feliz.Bulma
 
 module private ElementLiterals =
     let [<Literal>] ``is-checkradio`` = "is-checkradio"
-    let [<Literal>] ``checkbox`` = "checkbox"
-    let [<Literal>] ``radio`` = "radio"
 
 type Checkradio =
-    static member inline checkbox props = 
-        ElementBuilders.Input.propsWithType ElementLiterals.``is-checkradio`` ElementLiterals.``checkbox`` props
-    static member inline radio props = 
-        ElementBuilders.Input.propsWithType ElementLiterals.``is-checkradio`` ElementLiterals.``radio`` props
+    static member inline checkbox props =
+        ElementBuilders.Input.propsWithType ElementLiterals.``is-checkradio`` prop.type'.checkbox props
+    static member inline radio props =
+        ElementBuilders.Input.propsWithType ElementLiterals.``is-checkradio`` prop.type'.radio props

--- a/src/Feliz.Bulma/Bulma.fs
+++ b/src/Feliz.Bulma/Bulma.fs
@@ -114,41 +114,34 @@ module private ElementLiterals =
     let [<Literal>] ``panel-block`` = "panel-block"
     let [<Literal>] ``panel-icon`` = "panel-icon"
     let [<Literal>] ``tabs`` = "tabs"
-    let [<Literal>] ``text`` = "text"
-    let [<Literal>] ``password`` = "password"
-    let [<Literal>] ``email`` = "email"
-    let [<Literal>] ``tel`` = "tel"
-    let [<Literal>] ``number`` = "number"
-    let [<Literal>] ``submit`` = "submit"
-    let [<Literal>] ``reset`` = "reset"
     let [<Literal>] ``help`` = "help"
 
-open System
 open Feliz
 
+[<Fable.Core.Erase>]
 type Bulma =
     static member inline container props = ElementBuilders.Div.props ElementLiterals.``container`` props
     static member inline container (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``container`` elms
     static member inline container elm = ElementBuilders.Div.valueElm ElementLiterals.``container`` elm
     static member inline container s = ElementBuilders.Div.valueStr ElementLiterals.``container`` s
     static member inline container i = ElementBuilders.Div.valueInt ElementLiterals.``container`` i
-    
+
     static member inline level props = ElementBuilders.Nav.props ElementLiterals.``level`` props
     static member inline level (elms:#seq<ReactElement>) = ElementBuilders.Nav.children ElementLiterals.``level`` elms
     static member inline level elm = ElementBuilders.Nav.children ElementLiterals.``level`` elm
-    
+
     static member inline levelLeft props = ElementBuilders.Div.props ElementLiterals.``level-left`` props
     static member inline levelLeft (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``level-left`` elms
     static member inline levelLeft elm = ElementBuilders.Div.valueElm ElementLiterals.``level-left`` elm
     static member inline levelLeft s = ElementBuilders.Div.valueStr ElementLiterals.``level-left`` s
     static member inline levelLeft i = ElementBuilders.Div.valueInt ElementLiterals.``level-left`` i
-    
+
     static member inline levelRight props = ElementBuilders.Div.props ElementLiterals.``level-right`` props
     static member inline levelRight (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``level-right`` elms
     static member inline levelRight elm = ElementBuilders.Div.valueElm ElementLiterals.``level-right`` elm
     static member inline levelRight s = ElementBuilders.Div.valueStr ElementLiterals.``level-right`` s
     static member inline levelRight i = ElementBuilders.Div.valueInt ElementLiterals.``level-right`` i
-    
+
     static member inline levelItem props = ElementBuilders.Div.props ElementLiterals.``level-item`` props
     static member inline levelItem (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``level-item`` elms
     static member inline levelItem elm = ElementBuilders.Div.valueElm ElementLiterals.``level-item`` elm
@@ -158,37 +151,37 @@ type Bulma =
     static member inline media props = ElementBuilders.Article.props ElementLiterals.``media`` props
     static member inline media (elms:#seq<ReactElement>) = ElementBuilders.Article.children ElementLiterals.``media`` elms
     static member inline media elm = ElementBuilders.Article.valueElm ElementLiterals.``media`` elm
-    
+
     static member inline mediaLeft props = ElementBuilders.Div.props ElementLiterals.``media-left`` props
     static member inline mediaLeft (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``media-left`` elms
     static member inline mediaLeft elm = ElementBuilders.Div.valueElm ElementLiterals.``media-left`` elm
     static member inline mediaLeft s = ElementBuilders.Div.valueStr ElementLiterals.``media-left`` s
     static member inline mediaLeft i = ElementBuilders.Div.valueInt ElementLiterals.``media-left`` i
-    
+
     static member inline mediaRight props = ElementBuilders.Div.props ElementLiterals.``media-right`` props
     static member inline mediaRight (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``media-right`` elms
     static member inline mediaRight elm = ElementBuilders.Div.valueElm ElementLiterals.``media-right`` elm
     static member inline mediaRight s = ElementBuilders.Div.valueStr ElementLiterals.``media-right`` s
     static member inline mediaRight i = ElementBuilders.Div.valueInt ElementLiterals.``media-right`` i
-    
+
     static member inline mediaContent props = ElementBuilders.Div.props ElementLiterals.``media-content`` props
     static member inline mediaContent (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``media-content`` elms
     static member inline mediaContent elm = ElementBuilders.Div.valueElm ElementLiterals.``media-content`` elm
     static member inline mediaContent s = ElementBuilders.Div.valueStr ElementLiterals.``media-content`` s
     static member inline mediaContent i = ElementBuilders.Div.valueInt ElementLiterals.``media-content`` i
-    
+
     static member inline hero props = ElementBuilders.Div.props ElementLiterals.``hero`` props
     static member inline hero (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``hero`` elms
     static member inline hero elm = ElementBuilders.Div.valueElm ElementLiterals.``hero`` elm
     static member inline hero s = ElementBuilders.Div.valueStr ElementLiterals.``hero`` s
     static member inline hero i = ElementBuilders.Div.valueInt ElementLiterals.``hero`` i
-    
+
     static member inline heroBody props = ElementBuilders.Div.props ElementLiterals.``hero-body`` props
     static member inline heroBody (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``hero-body`` elms
     static member inline heroBody elm = ElementBuilders.Div.valueElm ElementLiterals.``hero-body`` elm
     static member inline heroBody s = ElementBuilders.Div.valueStr ElementLiterals.``hero-body`` s
     static member inline heroBody i = ElementBuilders.Div.valueInt ElementLiterals.``hero-body`` i
-    
+
     static member inline heroHead props = ElementBuilders.Div.props ElementLiterals.``hero-head`` props
     static member inline heroHead (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``hero-head`` elms
     static member inline heroHead elm = ElementBuilders.Div.valueElm ElementLiterals.``hero-head`` elm
@@ -200,532 +193,735 @@ type Bulma =
     static member inline heroFoot elm = ElementBuilders.Div.valueElm ElementLiterals.``hero-foot`` elm
     static member inline heroFoot s = ElementBuilders.Div.valueStr ElementLiterals.``hero-foot`` s
     static member inline heroFoot i = ElementBuilders.Div.valueInt ElementLiterals.``hero-foot`` i
-    
+
     static member inline section props = ElementBuilders.Section.props ElementLiterals.``section`` props
     static member inline section (elms:#seq<ReactElement>) = ElementBuilders.Section.children ElementLiterals.``section`` elms
-    
+
     static member inline footer props = ElementBuilders.Footer.props ElementLiterals.``footer`` props
     static member inline footer (elms:#seq<ReactElement>) = ElementBuilders.Footer.children ElementLiterals.``footer`` elms
     static member inline footer elm = ElementBuilders.Footer.valueElm ElementLiterals.``footer`` elm
-    
+
     static member inline tile props = ElementBuilders.Div.props ElementLiterals.``tile`` props
     static member inline tile (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``tile`` elms
     static member inline tile elm = ElementBuilders.Div.valueElm ElementLiterals.``tile`` elm
     static member inline tile s = ElementBuilders.Div.valueStr ElementLiterals.``tile`` s
     static member inline tile i = ElementBuilders.Div.valueInt ElementLiterals.``tile`` i
-    
+
     static member inline columns props = ElementBuilders.Div.props ElementLiterals.``columns`` props
     static member inline columns (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``columns`` elms
     static member inline columns elm = ElementBuilders.Div.valueElm ElementLiterals.``columns`` elm
     static member inline columns s = ElementBuilders.Div.valueStr ElementLiterals.``columns`` s
     static member inline columns i = ElementBuilders.Div.valueInt ElementLiterals.``columns`` i
-    
+
     static member inline column props = ElementBuilders.Div.props ElementLiterals.``column`` props
     static member inline column (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``column`` elms
     static member inline column elm = ElementBuilders.Div.valueElm ElementLiterals.``column`` elm
     static member inline column s = ElementBuilders.Div.valueStr ElementLiterals.``column`` s
     static member inline column i = ElementBuilders.Div.valueInt ElementLiterals.``column`` i
-    
-    static member inline field props = ElementBuilders.Div.props ElementLiterals.``field`` props
-    static member inline field (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``field`` elms
-    static member inline field elm = ElementBuilders.Div.valueElm ElementLiterals.``field`` elm
-    static member inline field s = ElementBuilders.Div.valueStr ElementLiterals.``field`` s
-    static member inline field i = ElementBuilders.Div.valueInt ElementLiterals.``field`` i
-    
+
     static member inline label props = ElementBuilders.Label.props ElementLiterals.``label`` props
     static member inline label (elms:#seq<ReactElement>) = ElementBuilders.Label.children ElementLiterals.``label`` elms
     static member inline label elm = ElementBuilders.Label.valueElm ElementLiterals.``label`` elm
     static member inline label s = ElementBuilders.Label.valueStr ElementLiterals.``label`` s
     static member inline label i = ElementBuilders.Label.valueInt ElementLiterals.``label`` i
-    
+
     static member inline fieldLabel props = ElementBuilders.Div.props ElementLiterals.``field-label`` props
     static member inline fieldLabel (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``field-label`` elms
     static member inline fieldLabel elm = ElementBuilders.Div.valueElm ElementLiterals.``field-label`` elm
     static member inline fieldLabel s = ElementBuilders.Div.valueStr ElementLiterals.``field-label`` s
     static member inline fieldLabel i = ElementBuilders.Div.valueInt ElementLiterals.``field-label`` i
-    
+
     static member inline fieldBody props = ElementBuilders.Div.props ElementLiterals.``field-body`` props
     static member inline fieldBody (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``field-body`` elms
     static member inline fieldBody elm = ElementBuilders.Div.valueElm ElementLiterals.``field-body`` elm
     static member inline fieldBody s = ElementBuilders.Div.valueStr ElementLiterals.``field-body`` s
     static member inline fieldBody i = ElementBuilders.Div.valueInt ElementLiterals.``field-body`` i
-    
-    static member inline control props = ElementBuilders.Div.props ElementLiterals.``control`` props
-    static member inline control (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``control`` elms
-    static member inline control elm = ElementBuilders.Div.valueElm ElementLiterals.``control`` elm
-    
-    static member inline textInput props = ElementBuilders.Input.propsWithType ElementLiterals.``input`` ElementLiterals.``text`` props
-    static member inline passwordInput props = ElementBuilders.Input.propsWithType ElementLiterals.``input`` ElementLiterals.``password`` props
-    static member inline emailInput props = ElementBuilders.Input.propsWithType ElementLiterals.``input`` ElementLiterals.``email`` props
-    static member inline telInput props = ElementBuilders.Input.propsWithType ElementLiterals.``input`` ElementLiterals.``tel`` props
-    static member inline numberInput props = ElementBuilders.Input.propsWithType ElementLiterals.``input`` ElementLiterals.``number`` props
-    
+
     static member inline textarea props = ElementBuilders.Textarea.props ElementLiterals.``textarea`` props
     static member inline textarea (elms:#seq<ReactElement>) = ElementBuilders.Textarea.children ElementLiterals.``textarea`` elms
-    static member inline textarea elm = ElementBuilders.Textarea.valueElm ElementLiterals.``textarea`` elm        
-    
+    static member inline textarea elm = ElementBuilders.Textarea.valueElm ElementLiterals.``textarea`` elm
+
     static member inline select props =
         let cp,nonCp = ElementBuilders.Helpers.partitionClasses props
         Html.div [ ElementBuilders.Helpers.combineClasses ElementLiterals.``select`` cp; prop.children [ Html.select nonCp ] ]
     static member inline select (elms:#seq<ReactElement>) = Html.div [ prop.className ElementLiterals.``select``; prop.children [ Html.select elms ] ]
     static member inline select (elm:ReactElement) = Html.div [ prop.className ElementLiterals.``select``; prop.children [ Html.select [ elm ] ] ]
-    
-    static member inline button props = ElementBuilders.Button.props ElementLiterals.``button`` props
-    static member inline button (elms:#seq<ReactElement>) = ElementBuilders.Button.children ElementLiterals.``button`` elms
-    static member inline button elm = ElementBuilders.Button.valueElm ElementLiterals.``button`` elm
-    static member inline button s = ElementBuilders.Button.valueStr ElementLiterals.``button`` s
-    static member inline button i = ElementBuilders.Button.valueInt ElementLiterals.``button`` i
-    
-    static member inline buttonLink props = ElementBuilders.A.props ElementLiterals.``button`` props
-    static member inline buttonLink (elms:#seq<ReactElement>) = ElementBuilders.A.children ElementLiterals.``button`` elms
-    static member inline buttonLink elm = ElementBuilders.A.valueElm ElementLiterals.``button`` elm
-    static member inline buttonLink s = ElementBuilders.A.valueStr ElementLiterals.``button`` s
-    static member inline buttonLink i = ElementBuilders.A.valueInt ElementLiterals.``button`` i
-    
-    static member inline buttonSubmit props = ElementBuilders.Input.propsWithType ElementLiterals.``button`` ElementLiterals.``submit`` props
-    static member inline buttonReset props = ElementBuilders.Input.propsWithType ElementLiterals.``button`` ElementLiterals.``reset`` props
-    
+
     static member inline checkboxLabel props = ElementBuilders.Label.props ElementLiterals.``checkbox`` props
     static member inline checkboxLabel (elms:#seq<ReactElement>) = ElementBuilders.Label.children ElementLiterals.``checkbox`` elms
     static member inline checkboxLabel elm = ElementBuilders.Label.valueElm ElementLiterals.``checkbox`` elm
-    
-    static member inline checkboxInput props = ElementBuilders.Input.propsWithType ElementLiterals.``checkbox`` ElementLiterals.``checkbox`` props
-    
+
+    static member inline checkboxInput props = ElementBuilders.Input.propsWithType ElementLiterals.``checkbox`` prop.type'.checkbox props
+
     static member inline radioLabel props = ElementBuilders.Label.props ElementLiterals.``radio`` props
     static member inline radioLabel (elms:#seq<ReactElement>) = ElementBuilders.Label.children ElementLiterals.``radio`` elms
     static member inline radioLabel elm = ElementBuilders.Label.valueElm ElementLiterals.``radio`` elm
 
-    static member inline radioInput props = ElementBuilders.Input.propsWithType ElementLiterals.``radio`` ElementLiterals.``radio`` props
-        
+    static member inline radioInput props = ElementBuilders.Input.propsWithType ElementLiterals.``radio`` prop.type'.radio props
+
     static member inline icon props = ElementBuilders.Span.props ElementLiterals.``icon`` props
     static member inline icon (elms:#seq<ReactElement>) = ElementBuilders.Span.children ElementLiterals.``icon`` elms
     static member inline icon elm = ElementBuilders.Span.valueElm ElementLiterals.``icon`` elm
-    
+
     static member inline file props = ElementBuilders.Div.props ElementLiterals.``file`` props
     static member inline file (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``file`` elms
     static member inline file elm = ElementBuilders.Div.valueElm ElementLiterals.``file`` elm
-    
+
     static member inline fileLabel props = ElementBuilders.Label.props ElementLiterals.``file-label`` props
     static member inline fileLabel (elms:#seq<ReactElement>) = ElementBuilders.Label.children ElementLiterals.``file-label`` elms
     static member inline fileLabel elm = ElementBuilders.Label.valueElm ElementLiterals.``file-label`` elm
     static member inline fileLabel s = ElementBuilders.Span.valueStr ElementLiterals.``file-label`` s
     static member inline fileLabel i = ElementBuilders.Span.valueInt ElementLiterals.``file-label`` i
-    
-    static member inline fileInput props = ElementBuilders.Input.propsWithType ElementLiterals.``file-input`` ElementLiterals.``file`` props
-    
+
+    static member inline fileInput props = ElementBuilders.Input.propsWithType ElementLiterals.``file-input`` prop.type'.file props
+
     static member inline fileCta props = ElementBuilders.Span.props ElementLiterals.``file-cta`` props
     static member inline fileCta (elms:#seq<ReactElement>) = ElementBuilders.Span.children ElementLiterals.``file-cta`` elms
     static member inline fileCta elm = ElementBuilders.Span.valueElm ElementLiterals.``file-cta`` elm
-    
+
     static member inline fileIcon props = ElementBuilders.Span.props ElementLiterals.``file-icon`` props
     static member inline fileIcon (elms:#seq<ReactElement>) = ElementBuilders.Span.children ElementLiterals.``file-icon`` elms
     static member inline fileIcon elm = ElementBuilders.Span.valueElm ElementLiterals.``file-icon`` elm
-    
+
     static member inline fileName props = ElementBuilders.Span.props ElementLiterals.``file-name`` props
     static member inline fileName (elms:#seq<ReactElement>) = ElementBuilders.Span.children ElementLiterals.``file-name`` elms
     static member inline fileName elm = ElementBuilders.Span.valueElm ElementLiterals.``file-name`` elm
     static member inline fileName s = ElementBuilders.Span.valueStr ElementLiterals.``file-name`` s
     static member inline fileName i = ElementBuilders.Span.valueInt ElementLiterals.``file-name`` i
-    
+
     static member inline box props = ElementBuilders.Div.props ElementLiterals.``box`` props
     static member inline box (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``box`` elms
     static member inline box elm = ElementBuilders.Div.valueElm ElementLiterals.``box`` elm
     static member inline box s = ElementBuilders.Div.valueStr ElementLiterals.``box`` s
     static member inline box i = ElementBuilders.Div.valueInt ElementLiterals.``box`` i
-    
+
     static member inline buttons props = ElementBuilders.Div.props ElementLiterals.``buttons`` props
     static member inline buttons (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``buttons`` elms
     static member inline buttons elm = ElementBuilders.Div.valueElm ElementLiterals.``buttons`` elm
-    
+
     static member inline content props = ElementBuilders.Div.props ElementLiterals.``content`` props
     static member inline content (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``content`` elms
     static member inline content elm = ElementBuilders.Div.valueElm ElementLiterals.``content`` elm
     static member inline content s = ElementBuilders.Div.valueStr ElementLiterals.``content`` s
     static member inline content i = ElementBuilders.Div.valueInt ElementLiterals.``content`` i
-    
+
     static member inline delete props = ElementBuilders.Button.props ElementLiterals.``delete`` props
-    
+
     static member inline image props = ElementBuilders.Figure.props ElementLiterals.``image`` props
     static member inline image (elms:#seq<ReactElement>) = ElementBuilders.Figure.children ElementLiterals.``image`` elms
     static member inline image elm = ElementBuilders.Figure.valueElm ElementLiterals.``image`` elm
-    
+
     static member inline notification props = ElementBuilders.Div.props ElementLiterals.``notification`` props
     static member inline notification (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``notification`` elms
     static member inline notification elm = ElementBuilders.Div.valueElm ElementLiterals.``notification`` elm
     static member inline notification s = ElementBuilders.Div.valueStr ElementLiterals.``notification`` s
     static member inline notification i = ElementBuilders.Div.valueInt ElementLiterals.``notification`` i
-    
+
     static member inline progress props = ElementBuilders.Div.props ElementLiterals.``progress`` props
     static member inline progress (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``progress`` elms
     static member inline progress elm = ElementBuilders.Div.valueElm ElementLiterals.``progress`` elm
     static member inline progress s = ElementBuilders.Div.valueStr ElementLiterals.``progress`` s
     static member inline progress i = ElementBuilders.Div.valueInt ElementLiterals.``progress`` i
-    
+
     static member inline table props = ElementBuilders.Table.props ElementLiterals.``table`` props
     static member inline table (elms:#seq<ReactElement>) = ElementBuilders.Table.children ElementLiterals.``table`` elms
     static member inline table elm = ElementBuilders.Table.valueElm ElementLiterals.``table`` elm
-    
+
     static member inline tableContainer props = ElementBuilders.Div.props ElementLiterals.``table-container`` props
     static member inline tableContainer (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``table-container`` elms
     static member inline tableContainer elm = ElementBuilders.Div.valueElm ElementLiterals.``table-container`` elm
-    
+
     static member inline tag props = ElementBuilders.Span.props ElementLiterals.``tag`` props
     static member inline tag (elms:#seq<ReactElement>) = ElementBuilders.Span.children ElementLiterals.``tag`` elms
     static member inline tag elm = ElementBuilders.Span.valueElm ElementLiterals.``tag`` elm
     static member inline tag s = ElementBuilders.Span.valueStr ElementLiterals.``tag`` s
     static member inline tag i = ElementBuilders.Span.valueInt ElementLiterals.``tag`` i
-    
+
     static member inline tags props = ElementBuilders.Div.props ElementLiterals.``tags`` props
     static member inline tags (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``tags`` elms
     static member inline tags elm = ElementBuilders.Div.valueElm ElementLiterals.``tags`` elm
-    
-    static member inline title props = ElementBuilders.H1.props ElementLiterals.``title`` props
-    static member inline title (elms:#seq<ReactElement>) = ElementBuilders.H1.children ElementLiterals.``title`` elms
-    static member inline title elm = ElementBuilders.H1.valueElm ElementLiterals.``title`` elm
-    static member inline title s = ElementBuilders.H1.valueStr ElementLiterals.``title`` s
-    static member inline title i = ElementBuilders.H1.valueInt ElementLiterals.``title`` i
-    
-    static member inline title1 props = ElementBuilders.H1.props ElementLiterals.``title is-1`` props
-    static member inline title1 (elms:#seq<ReactElement>) = ElementBuilders.H1.children ElementLiterals.``title is-1`` elms
-    static member inline title1 elm = ElementBuilders.H1.valueElm ElementLiterals.``title is-1`` elm
-    static member inline title1 s = ElementBuilders.H1.valueStr ElementLiterals.``title is-1`` s
-    static member inline title1 i = ElementBuilders.H1.valueInt ElementLiterals.``title is-1`` i
 
-    static member inline title2 props = ElementBuilders.H2.props ElementLiterals.``title is-2`` props
-    static member inline title2 (elms:#seq<ReactElement>) = ElementBuilders.H2.children ElementLiterals.``title is-2`` elms
-    static member inline title2 elm = ElementBuilders.H2.valueElm ElementLiterals.``title is-2`` elm
-    static member inline title2 s = ElementBuilders.H2.valueStr ElementLiterals.``title is-2`` s
-    static member inline title2 i = ElementBuilders.H2.valueInt ElementLiterals.``title is-2`` i
-
-    static member inline title3 props = ElementBuilders.H3.props ElementLiterals.``title is-3`` props
-    static member inline title3 (elms:#seq<ReactElement>) = ElementBuilders.H3.children ElementLiterals.``title is-3`` elms
-    static member inline title3 elm = ElementBuilders.H3.valueElm ElementLiterals.``title is-3`` elm
-    static member inline title3 s = ElementBuilders.H3.valueStr ElementLiterals.``title is-3`` s
-    static member inline title3 i = ElementBuilders.H3.valueInt ElementLiterals.``title is-3`` i
-
-    static member inline title4 props = ElementBuilders.H4.props ElementLiterals.``title is-4`` props
-    static member inline title4 (elms:#seq<ReactElement>) = ElementBuilders.H4.children ElementLiterals.``title is-4`` elms
-    static member inline title4 elm = ElementBuilders.H4.valueElm ElementLiterals.``title is-4`` elm
-    static member inline title4 s = ElementBuilders.H4.valueStr ElementLiterals.``title is-4`` s
-    static member inline title4 i = ElementBuilders.H4.valueInt ElementLiterals.``title is-4`` i
-
-    static member inline title5 props = ElementBuilders.H5.props ElementLiterals.``title is-5`` props
-    static member inline title5 (elms:#seq<ReactElement>) = ElementBuilders.H5.children ElementLiterals.``title is-5`` elms
-    static member inline title5 elm = ElementBuilders.H5.valueElm ElementLiterals.``title is-5`` elm
-    static member inline title5 s = ElementBuilders.H5.valueStr ElementLiterals.``title is-5`` s
-    static member inline title5 i = ElementBuilders.H5.valueInt ElementLiterals.``title is-5`` i
-
-    static member inline title6 props = ElementBuilders.H6.props ElementLiterals.``title is-6`` props
-    static member inline title6 (elms:#seq<ReactElement>) = ElementBuilders.H6.children ElementLiterals.``title is-6`` elms
-    static member inline title6 elm = ElementBuilders.H6.valueElm ElementLiterals.``title is-6`` elm
-    static member inline title6 s = ElementBuilders.H6.valueStr ElementLiterals.``title is-6`` s
-    static member inline title6 i = ElementBuilders.H6.valueInt ElementLiterals.``title is-6`` i
-    
-    static member inline subtitle props = ElementBuilders.H2.props ElementLiterals.``subtitle`` props
-    static member inline subtitle (elms:#seq<ReactElement>) = ElementBuilders.H2.children ElementLiterals.``subtitle`` elms
-    static member inline subtitle elm = ElementBuilders.H2.valueElm ElementLiterals.``subtitle`` elm
-    static member inline subtitle s = ElementBuilders.H2.valueStr ElementLiterals.``subtitle`` s
-    static member inline subtitle i = ElementBuilders.H2.valueInt ElementLiterals.``subtitle`` i
-    
-    static member inline subtitle1 props = ElementBuilders.H1.props ElementLiterals.``subtitle is-1`` props
-    static member inline subtitle1 (elms:#seq<ReactElement>) = ElementBuilders.H1.children ElementLiterals.``subtitle is-1`` elms
-    static member inline subtitle1 elm = ElementBuilders.H1.valueElm ElementLiterals.``subtitle is-1`` elm
-    static member inline subtitle1 s = ElementBuilders.H1.valueStr ElementLiterals.``subtitle is-1`` s
-    static member inline subtitle1 i = ElementBuilders.H1.valueInt ElementLiterals.``subtitle is-1`` i
-
-    static member inline subtitle2 props = ElementBuilders.H2.props ElementLiterals.``subtitle is-2`` props
-    static member inline subtitle2 (elms:#seq<ReactElement>) = ElementBuilders.H2.children ElementLiterals.``subtitle is-2`` elms
-    static member inline subtitle2 elm = ElementBuilders.H2.valueElm ElementLiterals.``subtitle is-2`` elm
-    static member inline subtitle2 s = ElementBuilders.H2.valueStr ElementLiterals.``subtitle is-2`` s
-    static member inline subtitle2 i = ElementBuilders.H2.valueInt ElementLiterals.``subtitle is-2`` i
-    
-    static member inline subtitle3 props = ElementBuilders.H3.props ElementLiterals.``subtitle is-3`` props
-    static member inline subtitle3 (elms:#seq<ReactElement>) = ElementBuilders.H3.children ElementLiterals.``subtitle is-3`` elms
-    static member inline subtitle3 elm = ElementBuilders.H3.valueElm ElementLiterals.``subtitle is-3`` elm
-    static member inline subtitle3 s = ElementBuilders.H3.valueStr ElementLiterals.``subtitle is-3`` s
-    static member inline subtitle3 i = ElementBuilders.H3.valueInt ElementLiterals.``subtitle is-3`` i
-
-    static member inline subtitle4 props = ElementBuilders.H4.props ElementLiterals.``subtitle is-4`` props
-    static member inline subtitle4 (elms:#seq<ReactElement>) = ElementBuilders.H4.children ElementLiterals.``subtitle is-4`` elms
-    static member inline subtitle4 elm = ElementBuilders.H4.valueElm ElementLiterals.``subtitle is-4`` elm
-    static member inline subtitle4 s = ElementBuilders.H4.valueStr ElementLiterals.``subtitle is-4`` s
-    static member inline subtitle4 i = ElementBuilders.H4.valueInt ElementLiterals.``subtitle is-4`` i
-
-    static member inline subtitle5 props = ElementBuilders.H5.props ElementLiterals.``subtitle is-5`` props
-    static member inline subtitle5 (elms:#seq<ReactElement>) = ElementBuilders.H5.children ElementLiterals.``subtitle is-5`` elms
-    static member inline subtitle5 elm = ElementBuilders.H5.valueElm ElementLiterals.``subtitle is-5`` elm
-    static member inline subtitle5 s = ElementBuilders.H5.valueStr ElementLiterals.``subtitle is-5`` s
-    static member inline subtitle5 i = ElementBuilders.H5.valueInt ElementLiterals.``subtitle is-5`` i
-
-    static member inline subtitle6 props = ElementBuilders.H6.props ElementLiterals.``subtitle is-6`` props
-    static member inline subtitle6 (elms:#seq<ReactElement>) = ElementBuilders.H6.children ElementLiterals.``subtitle is-6`` elms
-    static member inline subtitle6 elm = ElementBuilders.H6.valueElm ElementLiterals.``subtitle is-6`` elm
-    static member inline subtitle6 s = ElementBuilders.H6.valueStr ElementLiterals.``subtitle is-6`` s
-    static member inline subtitle6 i = ElementBuilders.H6.valueInt ElementLiterals.``subtitle is-6`` i
-    
     static member inline breadcrumb props = ElementBuilders.Nav.props ElementLiterals.``breadcrumb`` props
     static member inline breadcrumb (elms:#seq<ReactElement>) = ElementBuilders.Nav.children ElementLiterals.``breadcrumb`` elms
     static member inline breadcrumb elm = ElementBuilders.Nav.valueElm ElementLiterals.``breadcrumb`` elm
-    
+
     static member inline card props = ElementBuilders.Div.props ElementLiterals.``card`` props
     static member inline card (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``card`` elms
     static member inline card elm = ElementBuilders.Div.valueElm ElementLiterals.``card`` elm
-    
+
     static member inline cardHeader props = ElementBuilders.Div.props ElementLiterals.``card-header`` props
     static member inline cardHeader (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``card-header`` elms
     static member inline cardHeader elm = ElementBuilders.Div.valueElm ElementLiterals.``card-header`` elm
-    
+
     static member inline cardHeaderTitle props = ElementBuilders.Div.props ElementLiterals.``card-header-title`` props
     static member inline cardHeaderTitle (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``card-header-title`` elms
     static member inline cardHeaderTitle elm = ElementBuilders.Div.valueElm ElementLiterals.``card-header-title`` elm
     static member inline cardHeaderTitle s = ElementBuilders.Div.valueStr ElementLiterals.``card-header-title`` s
     static member inline cardHeaderTitle i = ElementBuilders.Div.valueInt ElementLiterals.``card-header-title`` i
-    
+
     static member inline cardHeaderIcon props = ElementBuilders.Span.props ElementLiterals.``card-header-icon`` props
     static member inline cardHeaderIcon (elms:#seq<ReactElement>) = ElementBuilders.Span.children ElementLiterals.``card-header-icon`` elms
     static member inline cardHeaderIcon elm = ElementBuilders.Span.valueElm ElementLiterals.``card-header-icon`` elm
-    
+
     static member inline cardImage props = ElementBuilders.Div.props ElementLiterals.``card-image`` props
     static member inline cardImage (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``card-image`` elms
     static member inline cardImage elm = ElementBuilders.Div.valueElm ElementLiterals.``card-image`` elm
-    
+
     static member inline cardContent props = ElementBuilders.Div.props ElementLiterals.``card-content`` props
     static member inline cardContent (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``card-content`` elms
     static member inline cardContent elm = ElementBuilders.Div.valueElm ElementLiterals.``card-content`` elm
     static member inline cardContent s = ElementBuilders.Div.valueStr ElementLiterals.``card-content`` s
     static member inline cardContent i = ElementBuilders.Div.valueInt ElementLiterals.``card-content`` i
-    
+
     static member inline cardFooter props = ElementBuilders.Footer.props ElementLiterals.``card-footer`` props
     static member inline cardFooter (elms:#seq<ReactElement>) = ElementBuilders.Footer.children ElementLiterals.``card-footer`` elms
     static member inline cardFooter elm = ElementBuilders.Footer.valueElm ElementLiterals.``card-footer`` elm
-    
-    static member inline cardFooterItem props = ElementBuilders.Div.props ElementLiterals.``card-footer-item`` props
-    static member inline cardFooterItem (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``card-footer-item`` elms
-    static member inline cardFooterItem elm = ElementBuilders.Div.valueElm ElementLiterals.``card-footer-item`` elm
-    static member inline cardFooterItem s = ElementBuilders.Div.valueStr ElementLiterals.``card-footer-item`` s
-    static member inline cardFooterItem i = ElementBuilders.Div.valueInt ElementLiterals.``card-footer-item`` i
-    
+
     static member inline dropdown props = ElementBuilders.Div.props ElementLiterals.``dropdown`` props
     static member inline dropdown (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``dropdown`` elms
     static member inline dropdown elm = ElementBuilders.Div.valueElm ElementLiterals.``dropdown`` elm
-    
+
     static member inline dropdownTrigger props = ElementBuilders.Div.props ElementLiterals.``dropdown-trigger`` props
     static member inline dropdownTrigger (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``dropdown-trigger`` elms
     static member inline dropdownTrigger elm = ElementBuilders.Div.valueElm ElementLiterals.``dropdown-trigger`` elm
-    
+
     static member inline dropdownMenu props = ElementBuilders.Div.props ElementLiterals.``dropdown-menu`` props
     static member inline dropdownMenu (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``dropdown-menu`` elms
     static member inline dropdownMenu elm = ElementBuilders.Div.valueElm ElementLiterals.``dropdown-menu`` elm
-    
+
     static member inline dropdownContent props = ElementBuilders.Div.props ElementLiterals.``dropdown-content`` props
     static member inline dropdownContent (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``dropdown-content`` elms
     static member inline dropdownContent elm = ElementBuilders.Div.valueElm ElementLiterals.``dropdown-content`` elm
-    
-    [<Obsolete("This method is deprecated and will be removed in future version. Please use Bulma.dropdownItemDiv or Bulma.dropdownItemA to specify concrete HTML tag used for rendering.")>]
-    static member inline dropdownItem props = ElementBuilders.Div.props ElementLiterals.``dropdown-item`` props
-    [<Obsolete("This method is deprecated and will be removed in future version. Please use Bulma.dropdownItemDiv or Bulma.dropdownItemA to specify concrete HTML tag used for rendering.")>]
-    static member inline dropdownItem (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``dropdown-item`` elms
-    [<Obsolete("This method is deprecated and will be removed in future version. Please use Bulma.dropdownItemDiv or Bulma.dropdownItemA to specify concrete HTML tag used for rendering.")>]
-    static member inline dropdownItem elm = ElementBuilders.Div.valueElm ElementLiterals.``dropdown-item`` elm
-    [<Obsolete("This method is deprecated and will be removed in future version. Please use Bulma.dropdownItemDiv or Bulma.dropdownItemA to specify concrete HTML tag used for rendering.")>]
-    static member inline dropdownItem s = ElementBuilders.Div.valueStr ElementLiterals.``dropdown-item`` s
-    [<Obsolete("This method is deprecated and will be removed in future version. Please use Bulma.dropdownItemDiv or Bulma.dropdownItemA to specify concrete HTML tag used for rendering.")>]
-    static member inline dropdownItem i = ElementBuilders.Div.valueInt ElementLiterals.``dropdown-item`` i
-    
-    static member inline dropdownItemA props = ElementBuilders.A.props ElementLiterals.``dropdown-item`` props
-    static member inline dropdownItemA (elms:#seq<ReactElement>) = ElementBuilders.A.children ElementLiterals.``dropdown-item`` elms
-    static member inline dropdownItemA elm = ElementBuilders.A.valueElm ElementLiterals.``dropdown-item`` elm
-    static member inline dropdownItemA s = ElementBuilders.A.valueStr ElementLiterals.``dropdown-item`` s
-    static member inline dropdownItemA i = ElementBuilders.A.valueInt ElementLiterals.``dropdown-item`` i
-    
-    static member inline dropdownItemDiv props = ElementBuilders.Div.props ElementLiterals.``dropdown-item`` props
-    static member inline dropdownItemDiv (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``dropdown-item`` elms
-    static member inline dropdownItemDiv elm = ElementBuilders.Div.valueElm ElementLiterals.``dropdown-item`` elm
-    static member inline dropdownItemDiv s = ElementBuilders.Div.valueStr ElementLiterals.``dropdown-item`` s
-    static member inline dropdownItemDiv i = ElementBuilders.Div.valueInt ElementLiterals.``dropdown-item`` i
-    
+
     static member inline dropdownDivider props = ElementBuilders.Hr.props ElementLiterals.``dropdown-divider`` props
-    
+
     static member inline menu props = ElementBuilders.Aside.props ElementLiterals.``menu`` props
     static member inline menu (elms:#seq<ReactElement>) = ElementBuilders.Aside.children ElementLiterals.``menu`` elms
     static member inline menu elm = ElementBuilders.Aside.valueElm ElementLiterals.``menu`` elm
-    
+
     static member inline menuLabel props = ElementBuilders.P.props ElementLiterals.``menu-label`` props
     static member inline menuLabel (elms:#seq<ReactElement>) = ElementBuilders.P.children ElementLiterals.``menu-label`` elms
     static member inline menuLabel elm = ElementBuilders.P.valueElm ElementLiterals.``menu-label`` elm
     static member inline menuLabel s = ElementBuilders.P.valueStr ElementLiterals.``menu-label`` s
     static member inline menuLabel i = ElementBuilders.P.valueInt ElementLiterals.``menu-label`` i
-    
+
     static member inline menuList props = ElementBuilders.Ul.props ElementLiterals.``menu-list`` props
     static member inline menuList (elms:#seq<ReactElement>) = ElementBuilders.Ul.children ElementLiterals.``menu-list`` elms
     static member inline menuList elm = ElementBuilders.Ul.valueElm ElementLiterals.``menu-list`` elm
-    
-    static member inline menuItem props = Html.li [ ElementBuilders.A.props "" props ]
-    static member inline menuItem (elms:#seq<ReactElement>) = Html.li [ prop.children (ElementBuilders.A.children "" elms) ]
-    static member inline menuItem elm = Html.li [ prop.children (ElementBuilders.A.valueElm "" elm) ]
-    static member inline menuItem s = Html.li [ ElementBuilders.A.valueStr "" s ]
-    static member inline menuItem i = Html.li [ ElementBuilders.A.valueInt "" i ]
-    
+
     static member inline message props = ElementBuilders.Article.props ElementLiterals.``message`` props
     static member inline message (elms:#seq<ReactElement>) = ElementBuilders.Article.children ElementLiterals.``message`` elms
     static member inline message elm = ElementBuilders.Article.valueElm ElementLiterals.``message`` elm
-    
+
     static member inline messageHeader props = ElementBuilders.Div.props ElementLiterals.``message-header`` props
     static member inline messageHeader (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``message-header`` elms
     static member inline messageHeader elm = ElementBuilders.Div.valueElm ElementLiterals.``message-header`` elm
-    
+
     static member inline messageBody props = ElementBuilders.Div.props ElementLiterals.``message-body`` props
     static member inline messageBody (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``message-body`` elms
     static member inline messageBody elm = ElementBuilders.Div.valueElm ElementLiterals.``message-body`` elm
     static member inline messageBody s = ElementBuilders.Div.valueStr ElementLiterals.``message-body`` s
     static member inline messageBody i = ElementBuilders.Div.valueInt ElementLiterals.``message-body`` i
-    
+
     static member inline modal props = ElementBuilders.Div.props ElementLiterals.``modal`` props
     static member inline modal (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``modal`` elms
     static member inline modal elm = ElementBuilders.Div.valueElm ElementLiterals.``modal`` elm
-    
+
     static member inline modalBackground props = ElementBuilders.Div.props ElementLiterals.``modal-background`` props
     static member inline modalClose props = ElementBuilders.Button.props ElementLiterals.``modal-close`` props
-    
+
     static member inline modalContent props = ElementBuilders.Div.props ElementLiterals.``modal-content`` props
     static member inline modalContent (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``modal-content`` elms
     static member inline modalContent elm = ElementBuilders.Div.valueElm ElementLiterals.``modal-content`` elm
     static member inline modalContent s = ElementBuilders.Div.valueStr ElementLiterals.``modal-content`` s
     static member inline modalContent i = ElementBuilders.Div.valueInt ElementLiterals.``modal-content`` i
-    
+
     static member inline modalCard props = ElementBuilders.Div.props ElementLiterals.``modal-card`` props
     static member inline modalCard (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``modal-card`` elms
     static member inline modalCard elm = ElementBuilders.Div.valueElm ElementLiterals.``modal-card`` elm
-    
+
     static member inline modalCardHead props = ElementBuilders.Header.props ElementLiterals.``modal-card-head`` props
     static member inline modalCardHead (elms:#seq<ReactElement>) = ElementBuilders.Header.children ElementLiterals.``modal-card-head`` elms
     static member inline modalCardHead elm = ElementBuilders.Header.valueElm ElementLiterals.``modal-card-head`` elm
-    
+
     static member inline modalCardTitle props = ElementBuilders.P.props ElementLiterals.``modal-card-title`` props
     static member inline modalCardTitle (elms:#seq<ReactElement>) = ElementBuilders.P.children ElementLiterals.``modal-card-title`` elms
     static member inline modalCardTitle elm = ElementBuilders.P.valueElm ElementLiterals.``modal-card-title`` elm
     static member inline modalCardTitle s = ElementBuilders.P.valueStr ElementLiterals.``modal-card-title`` s
-    static member inline modalCardTitle i = ElementBuilders.P.valueInt ElementLiterals.``modal-card-title`` i    
-    
+    static member inline modalCardTitle i = ElementBuilders.P.valueInt ElementLiterals.``modal-card-title`` i
+
     static member inline modalCardBody props = ElementBuilders.Section.props ElementLiterals.``modal-card-body`` props
     static member inline modalCardBody (elms:#seq<ReactElement>) = ElementBuilders.Section.children ElementLiterals.``modal-card-body`` elms
     static member inline modalCardBody elm = ElementBuilders.Section.valueElm ElementLiterals.``modal-card-body`` elm
-    
+
     static member inline modalCardFoot props = ElementBuilders.Footer.props ElementLiterals.``modal-card-foot`` props
     static member inline modalCardFoot (elms:#seq<ReactElement>) = ElementBuilders.Footer.children ElementLiterals.``modal-card-foot`` elms
     static member inline modalCardFoot elm = ElementBuilders.Footer.valueElm ElementLiterals.``modal-card-foot`` elm
-    
+
     static member inline navbar props = ElementBuilders.Nav.props ElementLiterals.``navbar`` props
     static member inline navbar (elms:#seq<ReactElement>) = ElementBuilders.Nav.children ElementLiterals.``navbar`` elms
     static member inline navbar elm = ElementBuilders.Nav.valueElm ElementLiterals.``navbar`` elm
-    
-    static member inline navbarBrand props = ElementBuilders.Div.props ElementLiterals.``navbar-brand`` props
-    static member inline navbarBrand (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``navbar-brand`` elms
-    static member inline navbarBrand elm = ElementBuilders.Div.valueElm ElementLiterals.``navbar-brand`` elm    
-    
+
     static member inline navbarBurger props = ElementBuilders.A.props ElementLiterals.``navbar-burger`` props
     static member inline navbarBurger (elms:#seq<ReactElement>) = ElementBuilders.A.children ElementLiterals.``navbar-burger`` elms
     static member inline navbarBurger elm = ElementBuilders.A.valueElm ElementLiterals.``navbar-burger`` elm
-    
+
     static member inline navbarMenu props = ElementBuilders.Div.props ElementLiterals.``navbar-menu`` props
     static member inline navbarMenu (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``navbar-menu`` elms
-    static member inline navbarMenu elm = ElementBuilders.Div.valueElm ElementLiterals.``navbar-menu`` elm    
+    static member inline navbarMenu elm = ElementBuilders.Div.valueElm ElementLiterals.``navbar-menu`` elm
 
-    static member inline navbarStart props = ElementBuilders.Div.props ElementLiterals.``navbar-start`` props
-    static member inline navbarStart (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``navbar-start`` elms
-    static member inline navbarStart elm = ElementBuilders.Div.valueElm ElementLiterals.``navbar-start`` elm
-    
-    static member inline navbarEnd props = ElementBuilders.Div.props ElementLiterals.``navbar-end`` props
-    static member inline navbarEnd (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``navbar-end`` elms
-    static member inline navbarEnd elm = ElementBuilders.Div.valueElm ElementLiterals.``navbar-end`` elm    
-
-    [<Obsolete("This method is deprecated and will be removed in future version. Please use Bulma.navbarItemDiv or Bulma.navbarItemA to specify concrete HTML tag used for rendering.")>]
-    static member inline navbarItem props = ElementBuilders.Div.props ElementLiterals.``navbar-item`` props
-    [<Obsolete("This method is deprecated and will be removed in future version. Please use Bulma.navbarItemDiv or Bulma.navbarItemA to specify concrete HTML tag used for rendering.")>]
-    static member inline navbarItem (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``navbar-item`` elms
-    [<Obsolete("This method is deprecated and will be removed in future version. Please use Bulma.navbarItemDiv or Bulma.navbarItemA to specify concrete HTML tag used for rendering.")>]
-    static member inline navbarItem elm = ElementBuilders.Div.valueElm ElementLiterals.``navbar-item`` elm
-    
-    static member inline navbarItemDiv props = ElementBuilders.Div.props ElementLiterals.``navbar-item`` props
-    static member inline navbarItemDiv (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``navbar-item`` elms
-    static member inline navbarItemDiv elm = ElementBuilders.Div.valueElm ElementLiterals.``navbar-item`` elm
-    
-    static member inline navbarItemA props = ElementBuilders.A.props ElementLiterals.``navbar-item`` props
-    static member inline navbarItemA (elms:#seq<ReactElement>) = ElementBuilders.A.children ElementLiterals.``navbar-item`` elms
-    static member inline navbarItemA elm = ElementBuilders.A.valueElm ElementLiterals.``navbar-item`` elm
-
-    static member inline navbarLink props = ElementBuilders.A.props ElementLiterals.``navbar-link`` props
-    static member inline navbarLink (elms:#seq<ReactElement>) = ElementBuilders.A.children ElementLiterals.``navbar-link`` elms
-    static member inline navbarLink elm = ElementBuilders.A.valueElm ElementLiterals.``navbar-link`` elm
-    static member inline navbarLink s = ElementBuilders.A.valueStr ElementLiterals.``navbar-link`` s
-    static member inline navbarLink i = ElementBuilders.A.valueInt ElementLiterals.``navbar-link`` i
-    
-    static member inline navbarDropdown props = ElementBuilders.Div.props ElementLiterals.``navbar-dropdown`` props
-    static member inline navbarDropdown (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``navbar-dropdown`` elms
-    static member inline navbarDropdown elm = ElementBuilders.Div.valueElm ElementLiterals.``navbar-dropdown`` elm
-    
     static member inline navbarDivider props = ElementBuilders.Hr.props ElementLiterals.``navbar-divider`` props
-    
+
     static member inline pagination props = ElementBuilders.Nav.props ElementLiterals.``pagination`` props
     static member inline pagination (elms:#seq<ReactElement>) = ElementBuilders.Nav.children ElementLiterals.``pagination`` elms
     static member inline pagination elm = ElementBuilders.Nav.valueElm ElementLiterals.``pagination`` elm
-    
-    static member inline paginationPrevious props = ElementBuilders.A.props ElementLiterals.``pagination-previous`` props
-    static member inline paginationPrevious (elms:#seq<ReactElement>) = ElementBuilders.A.children ElementLiterals.``pagination-previous`` elms
-    static member inline paginationPrevious elm = ElementBuilders.A.valueElm ElementLiterals.``pagination-previous`` elm
-    static member inline paginationPrevious s = ElementBuilders.A.valueStr ElementLiterals.``pagination-previous`` s
-    static member inline paginationPrevious i = ElementBuilders.A.valueInt ElementLiterals.``pagination-previous`` i
-    
-    static member inline paginationNext props = ElementBuilders.A.props ElementLiterals.``pagination-next`` props
-    static member inline paginationNext (elms:#seq<ReactElement>) = ElementBuilders.A.children ElementLiterals.``pagination-next`` elms
-    static member inline paginationNext elm = ElementBuilders.A.valueElm ElementLiterals.``pagination-next`` elm
-    static member inline paginationNext s = ElementBuilders.A.valueStr ElementLiterals.``pagination-next`` s
-    static member inline paginationNext i = ElementBuilders.A.valueInt ElementLiterals.``pagination-next`` i
-    
+
     static member inline paginationList props = ElementBuilders.Ul.props ElementLiterals.``pagination-list`` props
     static member inline paginationList (elms:#seq<ReactElement>) = ElementBuilders.Ul.children ElementLiterals.``pagination-list`` elms
     static member inline paginationList elm = ElementBuilders.Ul.valueElm ElementLiterals.``pagination-list`` elm
-    
-    static member inline paginationLink props = ElementBuilders.A.props ElementLiterals.``pagination-link`` props
-    static member inline paginationLink (elms:#seq<ReactElement>) = ElementBuilders.A.children ElementLiterals.``pagination-link`` elms
-    static member inline paginationLink elm = ElementBuilders.A.valueElm ElementLiterals.``pagination-link`` elm
-    static member inline paginationLink s = ElementBuilders.A.valueStr ElementLiterals.``pagination-link`` s
-    static member inline paginationLink i = ElementBuilders.A.valueInt ElementLiterals.``pagination-link`` i
-    
+
     static member inline paginationEllipsis props = ElementBuilders.Span.props ElementLiterals.``pagination-ellipsis`` props
     static member inline paginationEllipsis (elms:#seq<ReactElement>) = ElementBuilders.Span.children ElementLiterals.``pagination-ellipsis`` elms
     static member inline paginationEllipsis elm = ElementBuilders.Span.valueElm ElementLiterals.``pagination-ellipsis`` elm
     static member inline paginationEllipsis s = ElementBuilders.Span.valueStr ElementLiterals.``pagination-ellipsis`` s
     static member inline paginationEllipsis i = ElementBuilders.Span.valueInt ElementLiterals.``pagination-ellipsis`` i
-    
+
     static member inline panel props = ElementBuilders.Nav.props ElementLiterals.``panel`` props
     static member inline panel (elms:#seq<ReactElement>) = ElementBuilders.Nav.children ElementLiterals.``panel`` elms
     static member inline panel elm = ElementBuilders.Nav.valueElm ElementLiterals.``panel`` elm
-    
+
     static member inline panelHeading props = ElementBuilders.P.props ElementLiterals.``panel-heading`` props
     static member inline panelHeading (elms:#seq<ReactElement>) = ElementBuilders.P.children ElementLiterals.``panel-heading`` elms
-    static member inline panelHeading elm = ElementBuilders.P.valueElm ElementLiterals.``panel-heading`` elm    
-    
+    static member inline panelHeading elm = ElementBuilders.P.valueElm ElementLiterals.``panel-heading`` elm
+
     static member inline panelTabs props = ElementBuilders.P.props ElementLiterals.``panel-tabs`` props
     static member inline panelTabs (elms:#seq<ReactElement>) = ElementBuilders.P.children ElementLiterals.``panel-tabs`` elms
-    static member inline panelTabs elm = ElementBuilders.P.valueElm ElementLiterals.``panel-tabs`` elm    
-    
-    static member inline panelBlock props = ElementBuilders.Div.props ElementLiterals.``panel-block`` props
-    static member inline panelBlock (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``panel-block`` elms
-    static member inline panelBlock elm = ElementBuilders.Div.valueElm ElementLiterals.``panel-block`` elm
-    static member inline panelBlock s = ElementBuilders.Div.valueStr ElementLiterals.``panel-block`` s
-    static member inline panelBlock i = ElementBuilders.Div.valueInt ElementLiterals.``panel-block`` i    
-    
+    static member inline panelTabs elm = ElementBuilders.P.valueElm ElementLiterals.``panel-tabs`` elm
+
     static member inline panelIcon props = ElementBuilders.Span.props ElementLiterals.``panel-icon`` props
     static member inline panelIcon (elms:#seq<ReactElement>) = ElementBuilders.Span.children ElementLiterals.``panel-icon`` elms
-    static member inline panelIcon elm = ElementBuilders.Span.valueElm ElementLiterals.``panel-icon`` elm    
-    
+    static member inline panelIcon elm = ElementBuilders.Span.valueElm ElementLiterals.``panel-icon`` elm
+
     static member inline tabs props = ElementBuilders.Div.props ElementLiterals.``tabs`` props
     static member inline tabs (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``tabs`` elms
     static member inline tabs elm = ElementBuilders.Div.valueElm ElementLiterals.``tabs`` elm
-    
+
     static member inline help props = ElementBuilders.P.props ElementLiterals.``help`` props
     static member inline help (elms:#seq<ReactElement>) = ElementBuilders.P.children ElementLiterals.``help`` elms
     static member inline help elm = ElementBuilders.P.valueElm ElementLiterals.``help`` elm
     static member inline help s = ElementBuilders.P.valueStr ElementLiterals.``help`` s
     static member inline help i = ElementBuilders.P.valueInt ElementLiterals.``help`` i
+
+module Bulma =
+
+    [<Fable.Core.Erase>]
+    type cardFooterItem =
+        static member inline div props = ElementBuilders.Div.props ElementLiterals.``card-footer-item`` props
+        static member inline div (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``card-footer-item`` elms
+        static member inline div elm = ElementBuilders.Div.valueElm ElementLiterals.``card-footer-item`` elm
+        static member inline div s = ElementBuilders.Div.valueStr ElementLiterals.``card-footer-item`` s
+        static member inline div i = ElementBuilders.Div.valueInt ElementLiterals.``card-footer-item`` i
+
+        static member inline p props = ElementBuilders.P.props ElementLiterals.``card-footer-item`` props
+        static member inline p (elms:#seq<ReactElement>) = ElementBuilders.P.children ElementLiterals.``card-footer-item`` elms
+        static member inline p elm = ElementBuilders.P.valueElm ElementLiterals.``card-footer-item`` elm
+        static member inline p s = ElementBuilders.P.valueStr ElementLiterals.``card-footer-item`` s
+        static member inline p i = ElementBuilders.P.valueInt ElementLiterals.``card-footer-item`` i
+
+        static member inline a props = ElementBuilders.A.props ElementLiterals.``card-footer-item`` props
+        static member inline a (elms:#seq<ReactElement>) = ElementBuilders.A.children ElementLiterals.``card-footer-item`` elms
+        static member inline a elm = ElementBuilders.A.valueElm ElementLiterals.``card-footer-item`` elm
+        static member inline a s = ElementBuilders.A.valueStr ElementLiterals.``card-footer-item`` s
+        static member inline a i = ElementBuilders.A.valueInt ElementLiterals.``card-footer-item`` i
+
+    [<Fable.Core.Erase>]
+    type dropdownItem =
+        static member inline a props = ElementBuilders.A.props ElementLiterals.``dropdown-item`` props
+        static member inline a (elms:#seq<ReactElement>) = ElementBuilders.A.children ElementLiterals.``dropdown-item`` elms
+        static member inline a elm = ElementBuilders.A.valueElm ElementLiterals.``dropdown-item`` elm
+        static member inline a s = ElementBuilders.A.valueStr ElementLiterals.``dropdown-item`` s
+        static member inline a i = ElementBuilders.A.valueInt ElementLiterals.``dropdown-item`` i
+
+        static member inline div props = ElementBuilders.Div.props ElementLiterals.``dropdown-item`` props
+        static member inline div (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``dropdown-item`` elms
+        static member inline div elm = ElementBuilders.Div.valueElm ElementLiterals.``dropdown-item`` elm
+        static member inline div s = ElementBuilders.Div.valueStr ElementLiterals.``dropdown-item`` s
+        static member inline div i = ElementBuilders.Div.valueInt ElementLiterals.``dropdown-item`` i
+
+        static member inline button props = ElementBuilders.Button.props ElementLiterals.``dropdown-item`` props
+        static member inline button (elms:#seq<ReactElement>) = ElementBuilders.Button.children ElementLiterals.``dropdown-item`` elms
+        static member inline button elm = ElementBuilders.Button.valueElm ElementLiterals.``dropdown-item`` elm
+        static member inline button s = ElementBuilders.Button.valueStr ElementLiterals.``dropdown-item`` s
+        static member inline button i = ElementBuilders.Button.valueInt ElementLiterals.``dropdown-item`` i
+
+    [<Fable.Core.Erase>]
+    type menuItem =
+        static member inline a props = ElementBuilders.A.props "" props
+        static member inline a (elms:#seq<ReactElement>) = prop.children (ElementBuilders.A.children "" elms)
+        static member inline a elm = prop.children (ElementBuilders.A.valueElm "" elm)
+        static member inline a s = ElementBuilders.A.valueStr "" s
+        static member inline a i = ElementBuilders.A.valueInt "" i
+
+        /// <summary>
+        /// Generate &lt;li&gt;&lt;a&gt;&lt;a&gt;&lt;li&gt;
+        ///
+        /// You control the `a` element
+        /// </summary>
+        static member inline li props = Html.li [ ElementBuilders.A.props "" props ]
+        /// <summary>
+        /// Generate &lt;li&gt;&lt;a&gt;&lt;a&gt;&lt;li&gt;
+        ///
+        /// You control the `a` element
+        /// </summary>
+        static member inline li (elms:#seq<ReactElement>) = Html.li [ prop.children (ElementBuilders.A.children "" elms) ]
+        /// <summary>
+        /// Generate &lt;li&gt;&lt;a&gt;&lt;a&gt;&lt;li&gt;
+        ///
+        /// You control the `a` element
+        /// </summary>
+        static member inline li elm = Html.li [ prop.children (ElementBuilders.A.valueElm "" elm) ]
+        /// <summary>
+        /// Generate &lt;li&gt;&lt;a&gt;&lt;a&gt;&lt;li&gt;
+        ///
+        /// You control the `a` element
+        /// </summary>
+        static member inline li s = Html.li [ ElementBuilders.A.valueStr "" s ]
+        /// <summary>
+        /// Generate &lt;li&gt;&lt;a&gt;&lt;a&gt;&lt;li&gt;
+        ///
+        /// You control the `a` element
+        /// </summary>
+        static member inline li i = Html.li [ ElementBuilders.A.valueInt "" i ]
+
+    [<Fable.Core.Erase>]
+    type navbarItem =
+        static member inline div props = ElementBuilders.Div.props ElementLiterals.``navbar-item`` props
+        static member inline div (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``navbar-item`` elms
+        static member inline div elm = ElementBuilders.Div.valueElm ElementLiterals.``navbar-item`` elm
+
+        static member inline a props = ElementBuilders.A.props ElementLiterals.``navbar-item`` props
+        static member inline a (elms:#seq<ReactElement>) = ElementBuilders.A.children ElementLiterals.``navbar-item`` elms
+        static member inline a elm = ElementBuilders.A.valueElm ElementLiterals.``navbar-item`` elm
+
+    [<Fable.Core.Erase>]
+    type navbarLink =
+        static member inline a props = ElementBuilders.A.props ElementLiterals.``navbar-link`` props
+        static member inline a (elms:#seq<ReactElement>) = ElementBuilders.A.children ElementLiterals.``navbar-link`` elms
+        static member inline a elm = ElementBuilders.A.valueElm ElementLiterals.``navbar-link`` elm
+        static member inline a s = ElementBuilders.A.valueStr ElementLiterals.``navbar-link`` s
+        static member inline a i = ElementBuilders.A.valueInt ElementLiterals.``navbar-link`` i
+
+        static member inline div props = ElementBuilders.Div.props ElementLiterals.``navbar-link`` props
+        static member inline div (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``navbar-link`` elms
+        static member inline div elm = ElementBuilders.Div.valueElm ElementLiterals.``navbar-link`` elm
+        static member inline div s = ElementBuilders.Div.valueStr ElementLiterals.``navbar-link`` s
+        static member inline div i = ElementBuilders.Div.valueInt ElementLiterals.``navbar-link`` i
+
+    [<Fable.Core.Erase>]
+    type navbarDropdown =
+        static member inline div props = ElementBuilders.Div.props ElementLiterals.``navbar-dropdown`` props
+        static member inline div (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``navbar-dropdown`` elms
+        static member inline div elm = ElementBuilders.Div.valueElm ElementLiterals.``navbar-dropdown`` elm
+
+        static member inline a props = ElementBuilders.A.props ElementLiterals.``navbar-dropdown`` props
+        static member inline a (elms:#seq<ReactElement>) = ElementBuilders.A.children ElementLiterals.``navbar-dropdown`` elms
+        static member inline a elm = ElementBuilders.A.valueElm ElementLiterals.``navbar-dropdown`` elm
+
+    [<Fable.Core.Erase>]
+    type navbarBrand =
+        static member inline div props = ElementBuilders.Div.props ElementLiterals.``navbar-brand`` props
+        static member inline div (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``navbar-brand`` elms
+        static member inline div elm = ElementBuilders.Div.valueElm ElementLiterals.``navbar-brand`` elm
+
+        static member inline a props = ElementBuilders.A.props ElementLiterals.``navbar-brand`` props
+        static member inline a (elms:#seq<ReactElement>) = ElementBuilders.A.children ElementLiterals.``navbar-brand`` elms
+        static member inline a elm = ElementBuilders.A.valueElm ElementLiterals.``navbar-brand`` elm
+
+    [<Fable.Core.Erase>]
+    type navbarStart =
+        static member inline div props = ElementBuilders.Div.props ElementLiterals.``navbar-start`` props
+        static member inline div (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``navbar-start`` elms
+        static member inline div elm = ElementBuilders.Div.valueElm ElementLiterals.``navbar-start`` elm
+
+        static member inline a props = ElementBuilders.A.props ElementLiterals.``navbar-start`` props
+        static member inline a (elms:#seq<ReactElement>) = ElementBuilders.A.children ElementLiterals.``navbar-start`` elms
+        static member inline a elm = ElementBuilders.A.valueElm ElementLiterals.``navbar-start`` elm
+
+    [<Fable.Core.Erase>]
+    type navbarEnd =
+        static member inline div props = ElementBuilders.Div.props ElementLiterals.``navbar-end`` props
+        static member inline div (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``navbar-end`` elms
+        static member inline div elm = ElementBuilders.Div.valueElm ElementLiterals.``navbar-end`` elm
+
+        static member inline a props = ElementBuilders.A.props ElementLiterals.``navbar-end`` props
+        static member inline a (elms:#seq<ReactElement>) = ElementBuilders.A.children ElementLiterals.``navbar-end`` elms
+        static member inline a elm = ElementBuilders.A.valueElm ElementLiterals.``navbar-end`` elm
+
+    [<Fable.Core.Erase>]
+    type paginationPrevious =
+        static member inline a props = ElementBuilders.A.props ElementLiterals.``pagination-previous`` props
+        static member inline a (elms:#seq<ReactElement>) = ElementBuilders.A.children ElementLiterals.``pagination-previous`` elms
+        static member inline a elm = ElementBuilders.A.valueElm ElementLiterals.``pagination-previous`` elm
+        static member inline a s = ElementBuilders.A.valueStr ElementLiterals.``pagination-previous`` s
+        static member inline a i = ElementBuilders.A.valueInt ElementLiterals.``pagination-previous`` i
+
+        static member inline button props = ElementBuilders.Button.props ElementLiterals.``pagination-previous`` props
+        static member inline button (elms:#seq<ReactElement>) = ElementBuilders.Button.children ElementLiterals.``pagination-previous`` elms
+        static member inline button elm = ElementBuilders.Button.valueElm ElementLiterals.``pagination-previous`` elm
+        static member inline button s = ElementBuilders.Button.valueStr ElementLiterals.``pagination-previous`` s
+        static member inline button i = ElementBuilders.Button.valueInt ElementLiterals.``pagination-previous`` i
+
+    [<Fable.Core.Erase>]
+    type paginationNext =
+        static member inline a props = ElementBuilders.A.props ElementLiterals.``pagination-next`` props
+        static member inline a (elms:#seq<ReactElement>) = ElementBuilders.A.children ElementLiterals.``pagination-next`` elms
+        static member inline a elm = ElementBuilders.A.valueElm ElementLiterals.``pagination-next`` elm
+        static member inline a s = ElementBuilders.A.valueStr ElementLiterals.``pagination-next`` s
+        static member inline a i = ElementBuilders.A.valueInt ElementLiterals.``pagination-next`` i
+
+        static member inline button props = ElementBuilders.Button.props ElementLiterals.``pagination-next`` props
+        static member inline button (elms:#seq<ReactElement>) = ElementBuilders.Button.children ElementLiterals.``pagination-next`` elms
+        static member inline button elm = ElementBuilders.Button.valueElm ElementLiterals.``pagination-next`` elm
+        static member inline button s = ElementBuilders.Button.valueStr ElementLiterals.``pagination-next`` s
+        static member inline button i = ElementBuilders.Button.valueInt ElementLiterals.``pagination-next`` i
+
+    [<Fable.Core.Erase>]
+    type paginationLink =
+        /// <summary>
+        /// Generate &lt;li&gt;&lt;a class=&quot;pagination-link&quot;&gt;&lt;/a&gt;&lt;/li&gt;
+        ///
+        /// You control the `a` element
+        /// </summary>
+        static member inline a props = Html.li [ ElementBuilders.A.props ElementLiterals.``pagination-link`` props ]
+        /// <summary>
+        /// Generate &lt;li&gt;&lt;a class=&quot;pagination-link&quot;&gt;&lt;/a&gt;&lt;/li&gt;
+        ///
+        /// You control the `a` element
+        /// </summary>
+        static member inline a (elms:#seq<ReactElement>) = Html.li [ ElementBuilders.A.children ElementLiterals.``pagination-link`` elms ]
+        /// <summary>
+        /// Generate &lt;li&gt;&lt;a class=&quot;pagination-link&quot;&gt;&lt;/a&gt;&lt;/li&gt;
+        ///
+        /// You control the `a` element
+        /// </summary>
+        static member inline a elm = Html.li [ ElementBuilders.A.valueElm ElementLiterals.``pagination-link`` elm ]
+        /// <summary>
+        /// Generate &lt;li&gt;&lt;a class=&quot;pagination-link&quot;&gt;&lt;/a&gt;&lt;/li&gt;
+        ///
+        /// You control the `a` element
+        /// </summary>
+        static member inline a s = Html.li [ ElementBuilders.A.valueStr ElementLiterals.``pagination-link`` s ]
+        /// <summary>
+        /// Generate &lt;li&gt;&lt;a class=&quot;pagination-link&quot;&gt;&lt;/a&gt;&lt;/li&gt;
+        ///
+        /// You control the `a` element
+        /// </summary>
+        static member inline a i = Html.li [ ElementBuilders.A.valueInt ElementLiterals.``pagination-link`` i ]
+
+        /// <summary>
+        /// Generate &lt;li&gt;&lt;button class=&quot;pagination-link&quot;&gt;&lt;/button&gt;&lt;/li&gt;
+        ///
+        /// You control the `button` element
+        /// </summary>
+        static member inline button props = Html.li [ ElementBuilders.Button.props ElementLiterals.``pagination-link`` props ]
+        /// <summary>
+        /// Generate &lt;li&gt;&lt;button class=&quot;pagination-link&quot;&gt;&lt;/button&gt;&lt;/li&gt;
+        ///
+        /// You control the `button` element
+        /// </summary>
+        static member inline button (elms:#seq<ReactElement>) = Html.li [ ElementBuilders.Button.children ElementLiterals.``pagination-link`` elms ]
+        /// <summary>
+        /// Generate &lt;li&gt;&lt;button class=&quot;pagination-link&quot;&gt;&lt;/button&gt;&lt;/li&gt;
+        ///
+        /// You control the `button` element
+        /// </summary>
+        static member inline button elm = Html.li [ ElementBuilders.Button.valueElm ElementLiterals.``pagination-link`` elm ]
+        /// <summary>
+        /// Generate &lt;li&gt;&lt;button class=&quot;pagination-link&quot;&gt;&lt;/button&gt;&lt;/li&gt;
+        ///
+        /// You control the `button` element
+        /// </summary>
+        static member inline button s = Html.li [ ElementBuilders.Button.valueStr ElementLiterals.``pagination-link`` s ]
+        /// <summary>
+        /// Generate &lt;li&gt;&lt;button class=&quot;pagination-link&quot;&gt;&lt;/button&gt;&lt;/li&gt;
+        ///
+        /// You control the `button` element
+        /// </summary>
+        static member inline button i = Html.li [ ElementBuilders.Button.valueInt ElementLiterals.``pagination-link`` i ]
+
+    [<Fable.Core.Erase>]
+    type panelBlock =
+        static member inline div props = ElementBuilders.Div.props ElementLiterals.``panel-block`` props
+        static member inline div (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``panel-block`` elms
+        static member inline div elm = ElementBuilders.Div.valueElm ElementLiterals.``panel-block`` elm
+        static member inline div s = ElementBuilders.Div.valueStr ElementLiterals.``panel-block`` s
+        static member inline div i = ElementBuilders.Div.valueInt ElementLiterals.``panel-block`` i
+
+        static member inline a props = ElementBuilders.A.props ElementLiterals.``panel-block`` props
+        static member inline a (elms:#seq<ReactElement>) = ElementBuilders.A.children ElementLiterals.``panel-block`` elms
+        static member inline a elm = ElementBuilders.A.valueElm ElementLiterals.``panel-block`` elm
+        static member inline a s = ElementBuilders.A.valueStr ElementLiterals.``panel-block`` s
+        static member inline a i = ElementBuilders.A.valueInt ElementLiterals.``panel-block`` i
+
+        static member inline label props = ElementBuilders.Label.props ElementLiterals.``panel-block`` props
+        static member inline label (elms:#seq<ReactElement>) = ElementBuilders.Label.children ElementLiterals.``panel-block`` elms
+        static member inline label elm = ElementBuilders.Label.valueElm ElementLiterals.``panel-block`` elm
+        static member inline label s = ElementBuilders.Label.valueStr ElementLiterals.``panel-block`` s
+        static member inline label i = ElementBuilders.Label.valueInt ElementLiterals.``panel-block`` i
+
+        static member inline p props = ElementBuilders.P.props ElementLiterals.``panel-block`` props
+        static member inline p (elms:#seq<ReactElement>) = ElementBuilders.P.children ElementLiterals.``panel-block`` elms
+        static member inline p elm = ElementBuilders.P.valueElm ElementLiterals.``panel-block`` elm
+        static member inline p s = ElementBuilders.P.valueStr ElementLiterals.``panel-block`` s
+        static member inline p i = ElementBuilders.P.valueInt ElementLiterals.``panel-block`` i
+
+    [<Fable.Core.Erase>]
+    type button =
+        static member inline button props = ElementBuilders.Button.props ElementLiterals.``button`` props
+        static member inline button (elms:#seq<ReactElement>) = ElementBuilders.Button.children ElementLiterals.``button`` elms
+        static member inline button elm = ElementBuilders.Button.valueElm ElementLiterals.``button`` elm
+        static member inline button s = ElementBuilders.Button.valueStr ElementLiterals.``button`` s
+        static member inline button i = ElementBuilders.Button.valueInt ElementLiterals.``button`` i
+
+        static member inline a props = ElementBuilders.A.props ElementLiterals.``button`` props
+        static member inline a (elms:#seq<ReactElement>) = ElementBuilders.A.children ElementLiterals.``button`` elms
+        static member inline a elm = ElementBuilders.A.valueElm ElementLiterals.``button`` elm
+        static member inline a s = ElementBuilders.A.valueStr ElementLiterals.``button`` s
+        static member inline a i = ElementBuilders.A.valueInt ElementLiterals.``button`` i
+
+        static member inline span props = ElementBuilders.Span.props ElementLiterals.``button`` props
+        static member inline span (elms:#seq<ReactElement>) = ElementBuilders.Span.children ElementLiterals.``button`` elms
+        static member inline span elm = ElementBuilders.Span.valueElm ElementLiterals.``button`` elm
+        static member inline span s = ElementBuilders.Span.valueStr ElementLiterals.``button`` s
+        static member inline span i = ElementBuilders.Span.valueInt ElementLiterals.``button`` i
+
+        static member inline submit props = ElementBuilders.Input.propsWithType ElementLiterals.``button`` prop.type'.submit props
+        static member inline reset props = ElementBuilders.Input.propsWithType ElementLiterals.``button`` prop.type'.reset props
+
+    [<Fable.Core.Erase>]
+    type title =
+        static member inline h1 props = ElementBuilders.H1.props ElementLiterals.``title`` props
+        static member inline h1 (elms:#seq<ReactElement>) = ElementBuilders.H1.children ElementLiterals.``title`` elms
+        static member inline h1 elm = ElementBuilders.H1.valueElm ElementLiterals.``title`` elm
+        static member inline h1 s = ElementBuilders.H1.valueStr ElementLiterals.``title`` s
+        static member inline h1 i = ElementBuilders.H1.valueInt ElementLiterals.``title`` i
+
+        static member inline h2 props = ElementBuilders.H2.props ElementLiterals.``title`` props
+        static member inline h2 (elms:#seq<ReactElement>) = ElementBuilders.H2.children ElementLiterals.``title`` elms
+        static member inline h2 elm = ElementBuilders.H2.valueElm ElementLiterals.``title`` elm
+        static member inline h2 s = ElementBuilders.H2.valueStr ElementLiterals.``title`` s
+        static member inline h2 i = ElementBuilders.H2.valueInt ElementLiterals.``title`` i
+
+        static member inline h3 props = ElementBuilders.H3.props ElementLiterals.``title`` props
+        static member inline h3 (elms:#seq<ReactElement>) = ElementBuilders.H3.children ElementLiterals.``title`` elms
+        static member inline h3 elm = ElementBuilders.H3.valueElm ElementLiterals.``title`` elm
+        static member inline h3 s = ElementBuilders.H3.valueStr ElementLiterals.``title`` s
+        static member inline h3 i = ElementBuilders.H3.valueInt ElementLiterals.``title`` i
+
+        static member inline h4 props = ElementBuilders.H4.props ElementLiterals.``title`` props
+        static member inline h4 (elms:#seq<ReactElement>) = ElementBuilders.H4.children ElementLiterals.``title`` elms
+        static member inline h4 elm = ElementBuilders.H4.valueElm ElementLiterals.``title`` elm
+        static member inline h4 s = ElementBuilders.H4.valueStr ElementLiterals.``title`` s
+        static member inline h4 i = ElementBuilders.H4.valueInt ElementLiterals.``title`` i
+
+        static member inline h5 props = ElementBuilders.H5.props ElementLiterals.``title`` props
+        static member inline h5 (elms:#seq<ReactElement>) = ElementBuilders.H5.children ElementLiterals.``title`` elms
+        static member inline h5 elm = ElementBuilders.H5.valueElm ElementLiterals.``title`` elm
+        static member inline h5 s = ElementBuilders.H5.valueStr ElementLiterals.``title`` s
+        static member inline h5 i = ElementBuilders.H5.valueInt ElementLiterals.``title`` i
+
+        static member inline h6 props = ElementBuilders.H6.props ElementLiterals.``title`` props
+        static member inline h6 (elms:#seq<ReactElement>) = ElementBuilders.H6.children ElementLiterals.``title`` elms
+        static member inline h6 elm = ElementBuilders.H6.valueElm ElementLiterals.``title`` elm
+        static member inline h6 s = ElementBuilders.H6.valueStr ElementLiterals.``title`` s
+        static member inline h6 i = ElementBuilders.H6.valueInt ElementLiterals.``title`` i
+
+        static member inline p props = ElementBuilders.P.props ElementLiterals.``title`` props
+        static member inline p (elms:#seq<ReactElement>) = ElementBuilders.P.children ElementLiterals.``title`` elms
+        static member inline p elm = ElementBuilders.P.valueElm ElementLiterals.``title`` elm
+        static member inline p s = ElementBuilders.P.valueStr ElementLiterals.``title`` s
+        static member inline p i = ElementBuilders.P.valueInt ElementLiterals.``title`` i
+
+    [<Fable.Core.Erase>]
+    type subtitle =
+        static member inline h1 props = ElementBuilders.H1.props ElementLiterals.``subtitle`` props
+        static member inline h1 (elms:#seq<ReactElement>) = ElementBuilders.H1.children ElementLiterals.``subtitle`` elms
+        static member inline h1 elm = ElementBuilders.H1.valueElm ElementLiterals.``subtitle`` elm
+        static member inline h1 s = ElementBuilders.H1.valueStr ElementLiterals.``subtitle`` s
+        static member inline h1 i = ElementBuilders.H1.valueInt ElementLiterals.``subtitle`` i
+
+        static member inline h2 props = ElementBuilders.H2.props ElementLiterals.``subtitle`` props
+        static member inline h2 (elms:#seq<ReactElement>) = ElementBuilders.H2.children ElementLiterals.``subtitle`` elms
+        static member inline h2 elm = ElementBuilders.H2.valueElm ElementLiterals.``subtitle`` elm
+        static member inline h2 s = ElementBuilders.H2.valueStr ElementLiterals.``subtitle`` s
+        static member inline h2 i = ElementBuilders.H2.valueInt ElementLiterals.``subtitle`` i
+
+        static member inline h3 props = ElementBuilders.H3.props ElementLiterals.``subtitle`` props
+        static member inline h3 (elms:#seq<ReactElement>) = ElementBuilders.H3.children ElementLiterals.``subtitle`` elms
+        static member inline h3 elm = ElementBuilders.H3.valueElm ElementLiterals.``subtitle`` elm
+        static member inline h3 s = ElementBuilders.H3.valueStr ElementLiterals.``subtitle`` s
+        static member inline h3 i = ElementBuilders.H3.valueInt ElementLiterals.``subtitle`` i
+
+        static member inline h4 props = ElementBuilders.H4.props ElementLiterals.``subtitle`` props
+        static member inline h4 (elms:#seq<ReactElement>) = ElementBuilders.H4.children ElementLiterals.``subtitle`` elms
+        static member inline h4 elm = ElementBuilders.H4.valueElm ElementLiterals.``subtitle`` elm
+        static member inline h4 s = ElementBuilders.H4.valueStr ElementLiterals.``subtitle`` s
+        static member inline h4 i = ElementBuilders.H4.valueInt ElementLiterals.``subtitle`` i
+
+        static member inline h5 props = ElementBuilders.H5.props ElementLiterals.``subtitle`` props
+        static member inline h5 (elms:#seq<ReactElement>) = ElementBuilders.H5.children ElementLiterals.``subtitle`` elms
+        static member inline h5 elm = ElementBuilders.H5.valueElm ElementLiterals.``subtitle`` elm
+        static member inline h5 s = ElementBuilders.H5.valueStr ElementLiterals.``subtitle`` s
+        static member inline h5 i = ElementBuilders.H5.valueInt ElementLiterals.``subtitle`` i
+
+        static member inline h6 props = ElementBuilders.H6.props ElementLiterals.``subtitle`` props
+        static member inline h6 (elms:#seq<ReactElement>) = ElementBuilders.H6.children ElementLiterals.``subtitle`` elms
+        static member inline h6 elm = ElementBuilders.H6.valueElm ElementLiterals.``subtitle`` elm
+        static member inline h6 s = ElementBuilders.H6.valueStr ElementLiterals.``subtitle`` s
+        static member inline h6 i = ElementBuilders.H6.valueInt ElementLiterals.``subtitle`` i
+
+        static member inline p props = ElementBuilders.P.props ElementLiterals.``subtitle`` props
+        static member inline p (elms:#seq<ReactElement>) = ElementBuilders.P.children ElementLiterals.``subtitle`` elms
+        static member inline p elm = ElementBuilders.P.valueElm ElementLiterals.``subtitle`` elm
+        static member inline p s = ElementBuilders.P.valueStr ElementLiterals.``subtitle`` s
+        static member inline p i = ElementBuilders.P.valueInt ElementLiterals.``subtitle`` i
+
+    [<Fable.Core.Erase>]
+    type control =
+        static member inline div props = ElementBuilders.Div.props ElementLiterals.``control`` props
+        static member inline div (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``control`` elms
+        static member inline div elm = ElementBuilders.Div.valueElm ElementLiterals.``control`` elm
+
+        static member inline p props = ElementBuilders.P.props ElementLiterals.``control`` props
+        static member inline p (elms:#seq<ReactElement>) = ElementBuilders.P.children ElementLiterals.``control`` elms
+        static member inline p elm = ElementBuilders.P.valueElm ElementLiterals.``control`` elm
+
+    [<Fable.Core.Erase>]
+    type field =
+        static member inline div props = ElementBuilders.Div.props ElementLiterals.``field`` props
+        static member inline div (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``field`` elms
+        static member inline div elm = ElementBuilders.Div.valueElm ElementLiterals.``field`` elm
+        static member inline div s = ElementBuilders.Div.valueStr ElementLiterals.``field`` s
+        static member inline div i = ElementBuilders.Div.valueInt ElementLiterals.``field`` i
+
+        static member inline p props = ElementBuilders.P.props ElementLiterals.``field`` props
+        static member inline p (elms:#seq<ReactElement>) = ElementBuilders.P.children ElementLiterals.``field`` elms
+        static member inline p elm = ElementBuilders.P.valueElm ElementLiterals.``field`` elm
+        static member inline p s = ElementBuilders.P.valueStr ElementLiterals.``field`` s
+        static member inline p i = ElementBuilders.P.valueInt ElementLiterals.``field`` i
+
+    [<Fable.Core.Erase>]
+    type input =
+        static member inline text props = ElementBuilders.Input.propsWithType ElementLiterals.``input`` prop.type'.text props
+        static member inline password props = ElementBuilders.Input.propsWithType ElementLiterals.``input`` prop.type'.password props
+        static member inline datetimeLocal props = ElementBuilders.Input.propsWithType ElementLiterals.``input`` prop.type'.dateTimeLocal props
+        static member inline date props = ElementBuilders.Input.propsWithType ElementLiterals.``input`` prop.type'.date props
+        static member inline month props = ElementBuilders.Input.propsWithType ElementLiterals.``input`` prop.type'.month props
+        static member inline time props = ElementBuilders.Input.propsWithType ElementLiterals.``input`` prop.type'.time props
+        static member inline week props = ElementBuilders.Input.propsWithType ElementLiterals.``input`` prop.type'.week props
+        static member inline url props = ElementBuilders.Input.propsWithType ElementLiterals.``input`` prop.type'.url props
+        static member inline search props = ElementBuilders.Input.propsWithType ElementLiterals.``input`` prop.type'.search props
+        static member inline color props = ElementBuilders.Input.propsWithType ElementLiterals.``input`` prop.type'.color props
+        static member inline email props = ElementBuilders.Input.propsWithType ElementLiterals.``input`` prop.type'.email props
+        static member inline tel props = ElementBuilders.Input.propsWithType ElementLiterals.``input`` prop.type'.tel props
+        static member inline number props = ElementBuilders.Input.propsWithType ElementLiterals.``input`` prop.type'.number props

--- a/src/Feliz.Bulma/ElementBuilders.fs
+++ b/src/Feliz.Bulma/ElementBuilders.fs
@@ -5,30 +5,30 @@ open Feliz.Bulma
 
 module internal Helpers =
     let [<Literal>] ClassName = "className"
-    
+
     let inline getClasses (xs:IReactProperty list) =
         xs
         |> List.map unbox<string * obj>
         |> List.filter (fun (v,_) -> v = ClassName)
         |> List.map (snd >> string)
-    
+
     let inline partitionClasses (xs:IReactProperty list) =
         xs
         |> List.partition (unbox<string * obj> >> fst >> ((=) ClassName))
-    
+
     let inline combineClasses cn (xs:IReactProperty list) =
         xs
         |> getClasses
         |> List.append [cn]
         |> fun x -> prop.classes x
-        
+
 module Div =
     let inline props (cn:string) (xs:IReactProperty list) = Html.div [ yield! xs; yield Helpers.combineClasses cn xs ]
     let inline children (cn:string) (children:seq<ReactElement>) = Html.div [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
     let inline valueStr (cn:string) (value:string) = Html.div [ prop.className cn; prop.text value ]
     let inline valueInt (cn:string) (value:int) = Html.div [ prop.className cn; prop.text value ]
-    
+
 module Nav =
     let inline props (cn:string) (xs:IReactProperty list) = Html.nav [ yield! xs; yield Helpers.combineClasses cn xs ]
     let inline children (cn:string) (children:seq<ReactElement>) = Html.nav [ prop.className cn; prop.children children ]
@@ -38,12 +38,12 @@ module Article =
     let inline props (cn:string) (xs:IReactProperty list) = Html.article [ yield! xs; yield Helpers.combineClasses cn xs ]
     let inline children (cn:string) (children:seq<ReactElement>) = Html.article [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
-    
+
 module Section =
     let inline props (cn:string) (xs:IReactProperty list) = Html.section [ yield! xs; yield Helpers.combineClasses cn xs ]
     let inline children (cn:string) (children:seq<ReactElement>) = Html.section [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
-    
+
 module Footer =
     let inline props (cn:string) (xs:IReactProperty list) = Html.footer [ yield! xs; yield Helpers.combineClasses cn xs ]
     let inline children (cn:string) (children:seq<ReactElement>) = Html.footer [ prop.className cn; prop.children children ]
@@ -55,16 +55,16 @@ module Label =
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
     let inline valueStr (cn:string) (value:string) = Html.label [ prop.className cn; prop.text value ]
     let inline valueInt (cn:string) (value:int) = Html.label [ prop.className cn; prop.text value ]
-    
+
 module Input =
-    let inline propsWithType (cn:string) (typ:string) (xs:IReactProperty list) =
-        Html.input [ yield! xs; yield PropertyBuilders.mkType typ; yield Helpers.combineClasses cn xs ]
-    
+    let inline propsWithType (cn:string) (typ: IReactProperty) (xs:IReactProperty list) =
+        Html.input [ yield! xs; typ; Helpers.combineClasses cn xs ]
+
 module Textarea =
     let inline props (cn:string) (xs:IReactProperty list) = Html.textarea [ yield! xs; yield Helpers.combineClasses cn xs ]
     let inline children (cn:string) (children:seq<ReactElement>) = Html.textarea [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
-    
+
 module Button =
     let inline props (cn:string) (xs:IReactProperty list) = Html.button [ yield! xs; yield Helpers.combineClasses cn xs ]
     let inline children (cn:string) (children:seq<ReactElement>) = Html.button [ prop.className cn; prop.children children ]
@@ -78,31 +78,31 @@ module Span =
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
     let inline valueStr (cn:string) (value:string) = Html.span [ prop.className cn; prop.text value ]
     let inline valueInt (cn:string) (value:int) = Html.span [ prop.className cn; prop.text value ]
-    
+
 module Figure =
     let inline props (cn:string) (xs:IReactProperty list) = Html.figure [ yield! xs; yield Helpers.combineClasses cn xs ]
     let inline children (cn:string) (children:seq<ReactElement>) = Html.figure [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
-    
+
 module Progress =
     let inline props (cn:string) (xs:IReactProperty list) = Html.progress [ yield! xs; yield Helpers.combineClasses cn xs ]
     let inline children (cn:string) (children:seq<ReactElement>) = Html.progress [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
     let inline valueStr (cn:string) (value:string) = Html.progress [ prop.className cn; prop.text value ]
     let inline valueInt (cn:string) (value:int) = Html.progress [ prop.className cn; prop.text value ]
-    
+
 module Table =
     let inline props (cn:string) (xs:IReactProperty list) = Html.table [ yield! xs; yield Helpers.combineClasses cn xs ]
     let inline children (cn:string) (children:seq<ReactElement>) = Html.table [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
-    
+
 module H1 =
     let inline props (cn:string) (xs:IReactProperty list) = Html.h1 [ yield! xs; yield Helpers.combineClasses cn xs ]
     let inline children (cn:string) (children:seq<ReactElement>) = Html.h1 [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
     let inline valueStr (cn:string) (value:string) = Html.h1 [ prop.className cn; prop.text value ]
     let inline valueInt (cn:string) (value:int) = Html.h1 [ prop.className cn; prop.text value ]
-    
+
 module H2 =
     let inline props (cn:string) (xs:IReactProperty list) = Html.h2 [ yield! xs; yield Helpers.combineClasses cn xs ]
     let inline children (cn:string) (children:seq<ReactElement>) = Html.h2 [ prop.className cn; prop.children children ]
@@ -116,42 +116,42 @@ module H3 =
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
     let inline valueStr (cn:string) (value:string) = Html.h3 [ prop.className cn; prop.text value ]
     let inline valueInt (cn:string) (value:int) = Html.h3 [ prop.className cn; prop.text value ]
-    
+
 module H4 =
     let inline props (cn:string) (xs:IReactProperty list) = Html.h4 [ yield! xs; yield Helpers.combineClasses cn xs ]
     let inline children (cn:string) (children:seq<ReactElement>) = Html.h4 [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
     let inline valueStr (cn:string) (value:string) = Html.h4 [ prop.className cn; prop.text value ]
     let inline valueInt (cn:string) (value:int) = Html.h4 [ prop.className cn; prop.text value ]
-    
+
 module H5 =
     let inline props (cn:string) (xs:IReactProperty list) = Html.h5 [ yield! xs; yield Helpers.combineClasses cn xs ]
     let inline children (cn:string) (children:seq<ReactElement>) = Html.h5 [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
     let inline valueStr (cn:string) (value:string) = Html.h5 [ prop.className cn; prop.text value ]
     let inline valueInt (cn:string) (value:int) = Html.h5 [ prop.className cn; prop.text value ]
-    
+
 module H6 =
     let inline props (cn:string) (xs:IReactProperty list) = Html.h6 [ yield! xs; yield Helpers.combineClasses cn xs ]
     let inline children (cn:string) (children:seq<ReactElement>) = Html.h6 [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
     let inline valueStr (cn:string) (value:string) = Html.h6 [ prop.className cn; prop.text value ]
     let inline valueInt (cn:string) (value:int) = Html.h6 [ prop.className cn; prop.text value ]
-    
+
 module Hr =
     let inline props (cn:string) (xs:IReactProperty list) = Html.hr [ yield! xs; yield Helpers.combineClasses cn xs ]
-    
+
 module Aside =
     let inline props (cn:string) (xs:IReactProperty list) = Html.aside [ yield! xs; yield Helpers.combineClasses cn xs ]
     let inline children (cn:string) (children:seq<ReactElement>) = Html.aside [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
-    
+
 module P =
     let inline props (cn:string) (xs:IReactProperty list) = Html.p [ yield! xs; yield Helpers.combineClasses cn xs ]
     let inline children (cn:string) (children:seq<ReactElement>) = Html.p [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
     let inline valueStr (cn:string) (value:string) = Html.p [ prop.className cn; prop.text value ]
-    let inline valueInt (cn:string) (value:int) = Html.p [ prop.className cn; prop.text value ]    
+    let inline valueInt (cn:string) (value:int) = Html.p [ prop.className cn; prop.text value ]
 
 module Ul =
     let inline props (cn:string) (xs:IReactProperty list) = Html.ul [ yield! xs; yield Helpers.combineClasses cn xs ]
@@ -162,10 +162,10 @@ module Header =
     let inline props (cn:string) (xs:IReactProperty list) = Html.header [ yield! xs; yield Helpers.combineClasses cn xs ]
     let inline children (cn:string) (children:seq<ReactElement>) = Html.header [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
-    
+
 module A =
     let inline props (cn:string) (xs:IReactProperty list) = Html.a [ yield! xs; yield Helpers.combineClasses cn xs ]
     let inline children (cn:string) (children:seq<ReactElement>) = Html.a [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
     let inline valueStr (cn:string) (value:string) = Html.a [ prop.className cn; prop.text value ]
-    let inline valueInt (cn:string) (value:int) = Html.a [ prop.className cn; prop.text value ]    
+    let inline valueInt (cn:string) (value:int) = Html.a [ prop.className cn; prop.text value ]

--- a/src/Feliz.Bulma/Modifiers.fs
+++ b/src/Feliz.Bulma/Modifiers.fs
@@ -373,7 +373,7 @@ module private ClassLiterals =
     let [<Literal>] ``is-variable`` = "is-variable"
     let [<Literal>] ``is-vcentered`` = "is-vcentered"
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type helpers =
     static member inline isClearfix = PropertyBuilders.mkClass ClassLiterals.``is-clearfix``
     static member inline isPulledLeft = PropertyBuilders.mkClass ClassLiterals.``is-pulled-left``
@@ -396,7 +396,7 @@ type helpers =
     static member inline isInlineFlex = PropertyBuilders.mkClass ClassLiterals.``is-inline-flex``
     static member inline isActive = PropertyBuilders.mkClass ClassLiterals.``is-active``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type size =
     static member inline isSize1 = PropertyBuilders.mkClass ClassLiterals.``is-size-1``
     static member inline isSize2 = PropertyBuilders.mkClass ClassLiterals.``is-size-2``
@@ -405,7 +405,7 @@ type size =
     static member inline isSize5 = PropertyBuilders.mkClass ClassLiterals.``is-size-5``
     static member inline isSize6 = PropertyBuilders.mkClass ClassLiterals.``is-size-6``
     static member inline isSize7 = PropertyBuilders.mkClass ClassLiterals.``is-size-7``
-    
+
     static member inline isSize1Mobile = PropertyBuilders.mkClass ClassLiterals.``is-size-1-mobile``
     static member inline isSize2Mobile = PropertyBuilders.mkClass ClassLiterals.``is-size-2-mobile``
     static member inline isSize3Mobile = PropertyBuilders.mkClass ClassLiterals.``is-size-3-mobile``
@@ -421,7 +421,7 @@ type size =
     static member inline isSize5Tablet = PropertyBuilders.mkClass ClassLiterals.``is-size-5-tablet``
     static member inline isSize6Tablet = PropertyBuilders.mkClass ClassLiterals.``is-size-6-tablet``
     static member inline isSize7Tablet = PropertyBuilders.mkClass ClassLiterals.``is-size-7-tablet``
-    
+
     static member inline isSize1Touch = PropertyBuilders.mkClass ClassLiterals.``is-size-1-touch``
     static member inline isSize2Touch = PropertyBuilders.mkClass ClassLiterals.``is-size-2-touch``
     static member inline isSize3Touch = PropertyBuilders.mkClass ClassLiterals.``is-size-3-touch``
@@ -454,35 +454,35 @@ type size =
     static member inline isSize6FullHd = PropertyBuilders.mkClass ClassLiterals.``is-size-6-fullhd``
     static member inline isSize7FullHd = PropertyBuilders.mkClass ClassLiterals.``is-size-7-fullhd``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type text =
     static member inline isFamilySansSerif = PropertyBuilders.mkClass ClassLiterals.``is-family-sans-serif``
     static member inline isFamilyMonospace = PropertyBuilders.mkClass ClassLiterals.``is-family-monospace``
     static member inline isFamilyPrimary = PropertyBuilders.mkClass ClassLiterals.``is-family-primary``
     static member inline isFamilySecondary = PropertyBuilders.mkClass ClassLiterals.``is-family-secondary``
     static member inline isFamilyCode = PropertyBuilders.mkClass ClassLiterals.``is-family-code``
-    
+
     static member inline isCapitalized = PropertyBuilders.mkClass ClassLiterals.``is-capitalized``
     static member inline isLowercase = PropertyBuilders.mkClass ClassLiterals.``is-lowercase``
     static member inline isUppercase = PropertyBuilders.mkClass ClassLiterals.``is-uppercase``
     static member inline isItalic= PropertyBuilders.mkClass ClassLiterals.``is-italic``
-    
+
     static member inline hasTextWeightLight = PropertyBuilders.mkClass ClassLiterals.``has-text-weight-light``
     static member inline hasTextWeightNormal = PropertyBuilders.mkClass ClassLiterals.``has-text-weight-normal``
     static member inline hasTextWeightMedium = PropertyBuilders.mkClass ClassLiterals.``has-text-weight-medium``
     static member inline hasTextWeightSemibold = PropertyBuilders.mkClass ClassLiterals.``has-text-weight-semibold``
     static member inline hasTextWeightBold = PropertyBuilders.mkClass ClassLiterals.``has-text-weight-bold``
-    
+
     static member inline hasTextCentered = PropertyBuilders.mkClass ClassLiterals.``has-text-centered``
     static member inline hasTextJustified = PropertyBuilders.mkClass ClassLiterals.``has-text-justified``
     static member inline hasTextLeft = PropertyBuilders.mkClass ClassLiterals.``has-text-left``
     static member inline hasTextRight = PropertyBuilders.mkClass ClassLiterals.``has-text-right``
-    
+
     static member inline hasTextCenteredMobile = PropertyBuilders.mkClass ClassLiterals.``has-text-centered-mobile``
     static member inline hasTextJustifiedMobile = PropertyBuilders.mkClass ClassLiterals.``has-text-justified-mobile``
     static member inline hasTextLeftMobile = PropertyBuilders.mkClass ClassLiterals.``has-text-left-mobile``
     static member inline hasTextRightMobile = PropertyBuilders.mkClass ClassLiterals.``has-text-right-mobile``
-    
+
     static member inline hasTextCenteredTablet = PropertyBuilders.mkClass ClassLiterals.``has-text-centered-tablet``
     static member inline hasTextJustifiedTablet = PropertyBuilders.mkClass ClassLiterals.``has-text-justified-tablet``
     static member inline hasTextLeftTablet = PropertyBuilders.mkClass ClassLiterals.``has-text-left-tablet``
@@ -502,7 +502,7 @@ type text =
     static member inline hasTextJustifiedDesktop = PropertyBuilders.mkClass ClassLiterals.``has-text-justified-desktop``
     static member inline hasTextLeftDesktop = PropertyBuilders.mkClass ClassLiterals.``has-text-left-desktop``
     static member inline hasTextRightDesktop = PropertyBuilders.mkClass ClassLiterals.``has-text-right-desktop``
-    
+
 
     static member inline hasTextCenteredDesktopOnly = PropertyBuilders.mkClass ClassLiterals.``has-text-centered-desktop-only``
     static member inline hasTextJustifiedDesktopOnly = PropertyBuilders.mkClass ClassLiterals.``has-text-justified-desktop-only``
@@ -522,9 +522,9 @@ type text =
     static member inline hasTextCenteredFullHd = PropertyBuilders.mkClass ClassLiterals.``has-text-centered-fullhd``
     static member inline hasTextJustifiedFullHd = PropertyBuilders.mkClass ClassLiterals.``has-text-justified-fullhd``
     static member inline hasTextLeftFullHd = PropertyBuilders.mkClass ClassLiterals.``has-text-left-fullhd``
-    static member inline hasTextRightFullHd = PropertyBuilders.mkClass ClassLiterals.``has-text-right-fullhd``    
-    
-[<Fable.Core.Erase>]       
+    static member inline hasTextRightFullHd = PropertyBuilders.mkClass ClassLiterals.``has-text-right-fullhd``
+
+[<Fable.Core.Erase>]
 type color =
     static member inline isWhite = PropertyBuilders.mkClass ClassLiterals.``is-white``
     static member inline isBlack = PropertyBuilders.mkClass ClassLiterals.``is-black``
@@ -536,7 +536,7 @@ type color =
     static member inline isSuccess = PropertyBuilders.mkClass ClassLiterals.``is-success``
     static member inline isWarning = PropertyBuilders.mkClass ClassLiterals.``is-warning``
     static member inline isDanger = PropertyBuilders.mkClass ClassLiterals.``is-danger``
-    
+
     static member inline hasTextWhite = PropertyBuilders.mkClass ClassLiterals.``has-text-white``
     static member inline hasTextBlack = PropertyBuilders.mkClass ClassLiterals.``has-text-black``
     static member inline hasTextLight = PropertyBuilders.mkClass ClassLiterals.``has-text-light``
@@ -556,7 +556,7 @@ type color =
     static member inline hasTextGreyLighter = PropertyBuilders.mkClass ClassLiterals.``has-text-grey-lighter``
     static member inline hasTextWhiteTer = PropertyBuilders.mkClass ClassLiterals.``has-text-white-ter``
     static member inline hasTextWhiteBis = PropertyBuilders.mkClass ClassLiterals.``has-text-white-bis``
-    
+
     static member inline hasBackgroundWhite = PropertyBuilders.mkClass ClassLiterals.``has-background-white``
     static member inline hasBackgroundBlack = PropertyBuilders.mkClass ClassLiterals.``has-background-black``
     static member inline hasBackgroundLight = PropertyBuilders.mkClass ClassLiterals.``has-background-light``
@@ -577,7 +577,7 @@ type color =
     static member inline hasBackgroundWhiteTer = PropertyBuilders.mkClass ClassLiterals.``has-background-white-ter``
     static member inline hasBackgroundWhiteBis = PropertyBuilders.mkClass ClassLiterals.``has-background-white-bis``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type image =
     static member inline is16x16 = PropertyBuilders.mkClass ClassLiterals.``is-16x16``
     static member inline is24x24 = PropertyBuilders.mkClass ClassLiterals.``is-24x24``
@@ -606,11 +606,11 @@ type image =
     static member inline isFullwidth = PropertyBuilders.mkClass ClassLiterals.``is-fullwidth``
     static member inline hasRatio = PropertyBuilders.mkClass ClassLiterals.``has-ratio``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type progress =
     static member inline value v = PropertyBuilders.mkValue v
     static member inline max v = PropertyBuilders.mkMax v
-    
+
     static member inline isWhite = PropertyBuilders.mkClass ClassLiterals.``is-white``
     static member inline isBlack = PropertyBuilders.mkClass ClassLiterals.``is-black``
     static member inline isLight = PropertyBuilders.mkClass ClassLiterals.``is-light``
@@ -622,26 +622,26 @@ type progress =
     static member inline isWarning = PropertyBuilders.mkClass ClassLiterals.``is-warning``
     static member inline isDanger = PropertyBuilders.mkClass ClassLiterals.``is-danger``
 
-[<Fable.Core.Erase>]       
-type table =    
-    static member inline isBordered = PropertyBuilders.mkClass ClassLiterals.``is-bordered``    
-    static member inline isStriped = PropertyBuilders.mkClass ClassLiterals.``is-striped``    
-    static member inline isNarrow = PropertyBuilders.mkClass ClassLiterals.``is-narrow``    
-    static member inline isHoverable = PropertyBuilders.mkClass ClassLiterals.``is-hoverable``    
-    static member inline isFullwidth = PropertyBuilders.mkClass ClassLiterals.``is-fullwidth``    
+[<Fable.Core.Erase>]
+type table =
+    static member inline isBordered = PropertyBuilders.mkClass ClassLiterals.``is-bordered``
+    static member inline isStriped = PropertyBuilders.mkClass ClassLiterals.``is-striped``
+    static member inline isNarrow = PropertyBuilders.mkClass ClassLiterals.``is-narrow``
+    static member inline isHoverable = PropertyBuilders.mkClass ClassLiterals.``is-hoverable``
+    static member inline isFullwidth = PropertyBuilders.mkClass ClassLiterals.``is-fullwidth``
 
-[<Fable.Core.Erase>]       
-type tr =    
-    static member inline isSelected = PropertyBuilders.mkClass ClassLiterals.``is-selected``    
+[<Fable.Core.Erase>]
+type tr =
+    static member inline isSelected = PropertyBuilders.mkClass ClassLiterals.``is-selected``
 
-[<Fable.Core.Erase>]       
-type tag =    
+[<Fable.Core.Erase>]
+type tag =
     static member inline isNormal = PropertyBuilders.mkClass ClassLiterals.``is-normal``
     static member inline isMedium = PropertyBuilders.mkClass ClassLiterals.``is-medium``
     static member inline isLarge = PropertyBuilders.mkClass ClassLiterals.``is-large``
     static member inline isRounded = PropertyBuilders.mkClass ClassLiterals.``is-rounded``
     static member inline isDelete = PropertyBuilders.mkClass ClassLiterals.``is-delete``
-    
+
     static member inline isWhite = PropertyBuilders.mkClass ClassLiterals.``is-white``
     static member inline isBlack = PropertyBuilders.mkClass ClassLiterals.``is-black``
     static member inline isLight = PropertyBuilders.mkClass ClassLiterals.``is-light``
@@ -653,18 +653,18 @@ type tag =
     static member inline isWarning = PropertyBuilders.mkClass ClassLiterals.``is-warning``
     static member inline isDanger = PropertyBuilders.mkClass ClassLiterals.``is-danger``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type tags =
     static member inline areSmall = PropertyBuilders.mkClass ClassLiterals.``are-small``
     static member inline areMedium = PropertyBuilders.mkClass ClassLiterals.``are-medium``
     static member inline areLarge = PropertyBuilders.mkClass ClassLiterals.``are-large``
     static member inline hasAddons = PropertyBuilders.mkClass ClassLiterals.``has-addons``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type title =
     static member inline isSpaced = PropertyBuilders.mkClass ClassLiterals.``is-spaced``
-    
-[<Fable.Core.Erase>]       
+
+[<Fable.Core.Erase>]
 type tabs =
     static member inline isActive = PropertyBuilders.mkClass ClassLiterals.``is-active``
     static member inline isCentered = PropertyBuilders.mkClass ClassLiterals.``is-centered``
@@ -677,7 +677,7 @@ type tabs =
     static member inline isToggleRounded = PropertyBuilders.mkClass ClassLiterals.``is-toggle-rounded``
     static member inline isFullwidth = PropertyBuilders.mkClass ClassLiterals.``is-fullwidth``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type breadcrumb =
     static member inline isCentered = PropertyBuilders.mkClass ClassLiterals.``is-centered``
     static member inline isRight = PropertyBuilders.mkClass ClassLiterals.``is-right``
@@ -689,11 +689,11 @@ type breadcrumb =
     static member inline isMedium = PropertyBuilders.mkClass ClassLiterals.``is-medium``
     static member inline isLarge = PropertyBuilders.mkClass ClassLiterals.``is-large``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type cardHeaderTitle =
     static member inline isCentered = PropertyBuilders.mkClass ClassLiterals.``is-centered``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type dropdown =
     static member inline isHoverable = PropertyBuilders.mkClass ClassLiterals.``is-hoverable``
     static member inline isActive = PropertyBuilders.mkClass ClassLiterals.``is-active``
@@ -713,21 +713,21 @@ type notification =
     static member inline isWarning = PropertyBuilders.mkClass ClassLiterals.``is-warning``
     static member inline isDanger = PropertyBuilders.mkClass ClassLiterals.``is-danger``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type modal =
     static member inline isActive = PropertyBuilders.mkClass ClassLiterals.``is-active``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type modalClose =
     static member inline isSmall = PropertyBuilders.mkClass ClassLiterals.``is-small``
     static member inline isNormal = PropertyBuilders.mkClass ClassLiterals.``is-normal``
     static member inline isMedium = PropertyBuilders.mkClass ClassLiterals.``is-medium``
     static member inline isLarge = PropertyBuilders.mkClass ClassLiterals.``is-large``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type navbar =
     static member inline isTransparent = PropertyBuilders.mkClass ClassLiterals.``is-transparent``
-    
+
     static member inline isWhite = PropertyBuilders.mkClass ClassLiterals.``is-white``
     static member inline isBlack = PropertyBuilders.mkClass ClassLiterals.``is-black``
     static member inline isLight = PropertyBuilders.mkClass ClassLiterals.``is-light``
@@ -739,26 +739,26 @@ type navbar =
     static member inline isWarning = PropertyBuilders.mkClass ClassLiterals.``is-warning``
     static member inline isDanger = PropertyBuilders.mkClass ClassLiterals.``is-danger``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type navbarMenu =
     static member inline isActive = PropertyBuilders.mkClass ClassLiterals.``is-active``
     static member inline isFixedTop = PropertyBuilders.mkClass ClassLiterals.``is-fixed-top``
     static member inline isFixedBottom = PropertyBuilders.mkClass ClassLiterals.``is-fixed-bottom``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type navbarBurger =
     static member inline isActive = PropertyBuilders.mkClass ClassLiterals.``is-active``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type navbarDropdown =
     static member inline isRight = PropertyBuilders.mkClass ClassLiterals.``is-right``
     static member inline isBoxed = PropertyBuilders.mkClass ClassLiterals.``is-boxed``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type navbarLink =
     static member inline isArrowless = PropertyBuilders.mkClass ClassLiterals.``is-arrowless``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type navbarItem =
     static member inline isExpanded = PropertyBuilders.mkClass ClassLiterals.``is-expanded``
     static member inline isTab = PropertyBuilders.mkClass ClassLiterals.``is-tab``
@@ -767,7 +767,7 @@ type navbarItem =
     static member inline isHoverable = PropertyBuilders.mkClass ClassLiterals.``is-hoverable``
     static member inline isActive = PropertyBuilders.mkClass ClassLiterals.``is-active``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type pagination =
     static member inline isCentered = PropertyBuilders.mkClass ClassLiterals.``is-centered``
     static member inline isRounded = PropertyBuilders.mkClass ClassLiterals.``is-rounded``
@@ -776,11 +776,11 @@ type pagination =
     static member inline isMedium = PropertyBuilders.mkClass ClassLiterals.``is-medium``
     static member inline isLarge = PropertyBuilders.mkClass ClassLiterals.``is-large``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type paginationLink =
     static member inline isCurrent = PropertyBuilders.mkClass ClassLiterals.``is-current``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type panel =
     static member inline isWhite = PropertyBuilders.mkClass ClassLiterals.``is-white``
     static member inline isBlack = PropertyBuilders.mkClass ClassLiterals.``is-black``
@@ -793,7 +793,7 @@ type panel =
     static member inline isWarning = PropertyBuilders.mkClass ClassLiterals.``is-warning``
     static member inline isDanger = PropertyBuilders.mkClass ClassLiterals.``is-danger``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type file =
     static member inline hasName = PropertyBuilders.mkClass ClassLiterals.``has-name``
     static member inline isRight = PropertyBuilders.mkClass ClassLiterals.``is-right``
@@ -804,7 +804,7 @@ type file =
     static member inline isNormal = PropertyBuilders.mkClass ClassLiterals.``is-normal``
     static member inline isMedium = PropertyBuilders.mkClass ClassLiterals.``is-medium``
     static member inline isLarge = PropertyBuilders.mkClass ClassLiterals.``is-large``
-    
+
     static member inline isWhite = PropertyBuilders.mkClass ClassLiterals.``is-white``
     static member inline isBlack = PropertyBuilders.mkClass ClassLiterals.``is-black``
     static member inline isLight = PropertyBuilders.mkClass ClassLiterals.``is-light``
@@ -816,7 +816,7 @@ type file =
     static member inline isWarning = PropertyBuilders.mkClass ClassLiterals.``is-warning``
     static member inline isDanger = PropertyBuilders.mkClass ClassLiterals.``is-danger``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type input =
     static member inline isSmall = PropertyBuilders.mkClass ClassLiterals.``is-small``
     static member inline isMedium = PropertyBuilders.mkClass ClassLiterals.``is-medium``
@@ -824,14 +824,14 @@ type input =
     static member inline isRounded = PropertyBuilders.mkClass ClassLiterals.``is-rounded``
     static member inline isHovered = PropertyBuilders.mkClass ClassLiterals.``is-hovered``
     static member inline isFocused = PropertyBuilders.mkClass ClassLiterals.``is-focused``
-    
+
     static member inline isPrimary = PropertyBuilders.mkClass ClassLiterals.``is-primary``
     static member inline isInfo = PropertyBuilders.mkClass ClassLiterals.``is-info``
     static member inline isSuccess = PropertyBuilders.mkClass ClassLiterals.``is-success``
     static member inline isWarning = PropertyBuilders.mkClass ClassLiterals.``is-warning``
     static member inline isDanger = PropertyBuilders.mkClass ClassLiterals.``is-danger``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type button =
     static member inline isStatic = PropertyBuilders.mkClass ClassLiterals.``is-static``
     static member inline isOutlined = PropertyBuilders.mkClass ClassLiterals.``is-outlined``
@@ -847,7 +847,7 @@ type button =
     static member inline isFocused = PropertyBuilders.mkClass ClassLiterals.``is-focused``
     static member inline isActive = PropertyBuilders.mkClass ClassLiterals.``is-active``
     static member inline isSelected = PropertyBuilders.mkClass ClassLiterals.``is-selected``
-    
+
     static member inline isWhite = PropertyBuilders.mkClass ClassLiterals.``is-white``
     static member inline isBlack = PropertyBuilders.mkClass ClassLiterals.``is-black``
     static member inline isLight = PropertyBuilders.mkClass ClassLiterals.``is-light``
@@ -858,10 +858,10 @@ type button =
     static member inline isSuccess = PropertyBuilders.mkClass ClassLiterals.``is-success``
     static member inline isWarning = PropertyBuilders.mkClass ClassLiterals.``is-warning``
     static member inline isDanger = PropertyBuilders.mkClass ClassLiterals.``is-danger``
-    
+
     static member inline isText = PropertyBuilders.mkClass ClassLiterals.``is-text``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type buttons =
     static member inline areSmall = PropertyBuilders.mkClass ClassLiterals.``are-small``
     static member inline areMedium = PropertyBuilders.mkClass ClassLiterals.``are-medium``
@@ -870,14 +870,14 @@ type buttons =
     static member inline isCentered = PropertyBuilders.mkClass ClassLiterals.``is-centered``
     static member inline isRight = PropertyBuilders.mkClass ClassLiterals.``is-right``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type fieldLabel =
     static member inline isSmall = PropertyBuilders.mkClass ClassLiterals.``is-small``
     static member inline isNormal = PropertyBuilders.mkClass ClassLiterals.``is-normal``
     static member inline isMedium = PropertyBuilders.mkClass ClassLiterals.``is-medium``
     static member inline isLarge = PropertyBuilders.mkClass ClassLiterals.``is-large``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type textarea =
     static member inline isSmall = PropertyBuilders.mkClass ClassLiterals.``is-small``
     static member inline isNormal = PropertyBuilders.mkClass ClassLiterals.``is-normal``
@@ -886,14 +886,14 @@ type textarea =
     static member inline isHovered = PropertyBuilders.mkClass ClassLiterals.``is-hovered``
     static member inline isFocused = PropertyBuilders.mkClass ClassLiterals.``is-focused``
     static member inline hasFixedSize = PropertyBuilders.mkClass ClassLiterals.``has-fixed-size``
-    
+
     static member inline isPrimary = PropertyBuilders.mkClass ClassLiterals.``is-primary``
     static member inline isInfo = PropertyBuilders.mkClass ClassLiterals.``is-info``
     static member inline isSuccess = PropertyBuilders.mkClass ClassLiterals.``is-success``
     static member inline isWarning = PropertyBuilders.mkClass ClassLiterals.``is-warning``
     static member inline isDanger = PropertyBuilders.mkClass ClassLiterals.``is-danger``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type field =
     static member inline hasAddons = PropertyBuilders.mkClass ClassLiterals.``has-addons``
     static member inline hasAddonsRight = PropertyBuilders.mkClass ClassLiterals.``has-addons-right``
@@ -918,14 +918,14 @@ type message =
     static member inline isWarning = PropertyBuilders.mkClass ClassLiterals.``is-warning``
     static member inline isDanger = PropertyBuilders.mkClass ClassLiterals.``is-danger``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type icon =
     static member inline isLeft = PropertyBuilders.mkClass ClassLiterals.``is-left``
     static member inline isRight = PropertyBuilders.mkClass ClassLiterals.``is-right``
     static member inline isSmall = PropertyBuilders.mkClass ClassLiterals.``is-small``
     static member inline isMedium = PropertyBuilders.mkClass ClassLiterals.``is-medium``
     static member inline isLarge = PropertyBuilders.mkClass ClassLiterals.``is-large``
-    
+
     static member inline hasTextWhite = PropertyBuilders.mkClass ClassLiterals.``has-text-white``
     static member inline hasTextBlack = PropertyBuilders.mkClass ClassLiterals.``has-text-black``
     static member inline hasTextLight = PropertyBuilders.mkClass ClassLiterals.``has-text-light``
@@ -946,7 +946,7 @@ type icon =
     static member inline hasTextWhiteTer = PropertyBuilders.mkClass ClassLiterals.``has-text-white-ter``
     static member inline hasTextWhiteBis = PropertyBuilders.mkClass ClassLiterals.``has-text-white-bis``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type select =
     static member inline isFullwidth = PropertyBuilders.mkClass ClassLiterals.``is-fullwidth``
     static member inline isMultiple = PropertyBuilders.mkClass ClassLiterals.``is-multiple``
@@ -958,14 +958,14 @@ type select =
     static member inline isHovered = PropertyBuilders.mkClass ClassLiterals.``is-hovered``
     static member inline isFocused = PropertyBuilders.mkClass ClassLiterals.``is-focused``
     static member inline isActive = PropertyBuilders.mkClass ClassLiterals.``is-active``
-    
+
     static member inline isPrimary = PropertyBuilders.mkClass ClassLiterals.``is-primary``
     static member inline isInfo = PropertyBuilders.mkClass ClassLiterals.``is-info``
     static member inline isSuccess = PropertyBuilders.mkClass ClassLiterals.``is-success``
     static member inline isWarning = PropertyBuilders.mkClass ClassLiterals.``is-warning``
     static member inline isDanger = PropertyBuilders.mkClass ClassLiterals.``is-danger``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type control =
     static member inline hasIconsLeft = PropertyBuilders.mkClass ClassLiterals.``has-icons-left``
     static member inline hasIconsRight = PropertyBuilders.mkClass ClassLiterals.``has-icons-right``
@@ -975,32 +975,32 @@ type control =
     static member inline isMedium = PropertyBuilders.mkClass ClassLiterals.``is-medium``
     static member inline isLarge = PropertyBuilders.mkClass ClassLiterals.``is-large``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type ol =
     static member inline isLowerAlpha = PropertyBuilders.mkClass ClassLiterals.``is-lower-alpha``
     static member inline isLowerRoman = PropertyBuilders.mkClass ClassLiterals.``is-lower-roman``
     static member inline isUpperAlpha = PropertyBuilders.mkClass ClassLiterals.``is-upper-alpha``
     static member inline isUpperRoman = PropertyBuilders.mkClass ClassLiterals.``is-upper-roman``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type content =
     static member inline isSmall = PropertyBuilders.mkClass ClassLiterals.``is-small``
     static member inline isMedium = PropertyBuilders.mkClass ClassLiterals.``is-medium``
     static member inline isLarge = PropertyBuilders.mkClass ClassLiterals.``is-large``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type delete =
     static member inline isSmall = PropertyBuilders.mkClass ClassLiterals.``is-small``
     static member inline isMedium = PropertyBuilders.mkClass ClassLiterals.``is-medium``
     static member inline isLarge = PropertyBuilders.mkClass ClassLiterals.``is-large``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type container =
     static member inline isFluid = PropertyBuilders.mkClass ClassLiterals.``is-fluid``
     static member inline isWidescreen = PropertyBuilders.mkClass ClassLiterals.``is-widescreen``
     static member inline isFullHd = PropertyBuilders.mkClass ClassLiterals.``is-fullhd``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type level =
     static member inline isMobile = PropertyBuilders.mkClass ClassLiterals.``is-mobile``
 
@@ -1009,14 +1009,14 @@ type section =
     static member inline isMedium = PropertyBuilders.mkClass ClassLiterals.``is-medium``
     static member inline isLarge = PropertyBuilders.mkClass ClassLiterals.``is-large``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type hero =
     static member inline isBold = PropertyBuilders.mkClass ClassLiterals.``is-bold``
     static member inline isMedium = PropertyBuilders.mkClass ClassLiterals.``is-medium``
     static member inline isLarge = PropertyBuilders.mkClass ClassLiterals.``is-large``
     static member inline isFullHeight = PropertyBuilders.mkClass ClassLiterals.``is-fullheight``
     static member inline isFullHeightWithNavbar = PropertyBuilders.mkClass ClassLiterals.``is-fullheight-with-navbar``
-    
+
     static member inline isPrimary = PropertyBuilders.mkClass ClassLiterals.``is-primary``
     static member inline isInfo = PropertyBuilders.mkClass ClassLiterals.``is-info``
     static member inline isSuccess = PropertyBuilders.mkClass ClassLiterals.``is-success``
@@ -1025,7 +1025,7 @@ type hero =
     static member inline isLight = PropertyBuilders.mkClass ClassLiterals.``is-light``
     static member inline isDark = PropertyBuilders.mkClass ClassLiterals.``is-dark``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type tile =
     static member inline isAncestor = PropertyBuilders.mkClass ClassLiterals.``is-ancestor``
     static member inline isParent = PropertyBuilders.mkClass ClassLiterals.``is-parent``
@@ -1044,7 +1044,7 @@ type tile =
     static member inline is11 = PropertyBuilders.mkClass ClassLiterals.``is-11``
     static member inline is12 = PropertyBuilders.mkClass ClassLiterals.``is-12``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type columns =
     static member inline isMobile = PropertyBuilders.mkClass ClassLiterals.``is-mobile``
     static member inline isDesktop = PropertyBuilders.mkClass ClassLiterals.``is-desktop``
@@ -1054,7 +1054,7 @@ type columns =
     static member inline isCentered = PropertyBuilders.mkClass ClassLiterals.``is-centered``
     static member inline isVcentered = PropertyBuilders.mkClass ClassLiterals.``is-vcentered``
 
-[<Fable.Core.Erase>]       
+[<Fable.Core.Erase>]
 type column =
     static member inline is1 = PropertyBuilders.mkClass ClassLiterals.``is-1``
     static member inline is2 = PropertyBuilders.mkClass ClassLiterals.``is-2``
@@ -1068,7 +1068,7 @@ type column =
     static member inline is10 = PropertyBuilders.mkClass ClassLiterals.``is-10``
     static member inline is11 = PropertyBuilders.mkClass ClassLiterals.``is-11``
     static member inline is12 = PropertyBuilders.mkClass ClassLiterals.``is-12``
-    
+
     static member inline isThreeQuarters = PropertyBuilders.mkClass ClassLiterals.``is-three-quarters``
     static member inline isTwoThirds = PropertyBuilders.mkClass ClassLiterals.``is-two-thirds``
     static member inline isHalf = PropertyBuilders.mkClass ClassLiterals.``is-half``
@@ -1086,7 +1086,7 @@ type column =
     static member inline isNarrowDesktop = PropertyBuilders.mkClass ClassLiterals.``is-narrow-desktop``
     static member inline isNarrowWidescreen = PropertyBuilders.mkClass ClassLiterals.``is-narrow-widescreen``
     static member inline isNarrowFullhd = PropertyBuilders.mkClass ClassLiterals.``is-narrow-fullhd``
-    
+
     static member inline isOffset1 = PropertyBuilders.mkClass ClassLiterals.``is-offset-1``
     static member inline isOffset2 = PropertyBuilders.mkClass ClassLiterals.``is-offset-2``
     static member inline isOffset3 = PropertyBuilders.mkClass ClassLiterals.``is-offset-3``
@@ -1109,7 +1109,7 @@ type column =
     static member inline isOffsetThreeFifths = PropertyBuilders.mkClass ClassLiterals.``is-offset-three-fifths``
     static member inline isOffsetTwoFifths = PropertyBuilders.mkClass ClassLiterals.``is-offset-two-fifths``
     static member inline isOffsetOneFifth = PropertyBuilders.mkClass ClassLiterals.``is-offset-one-fifth``
-    
+
     static member inline isThreeQuartersMobile = PropertyBuilders.mkClass ClassLiterals.``is-three-quarters-mobile``
     static member inline isTwoThirdsMobile = PropertyBuilders.mkClass ClassLiterals.``is-two-thirds-mobile``
     static member inline isHalfMobile = PropertyBuilders.mkClass ClassLiterals.``is-half-mobile``
@@ -1160,8 +1160,8 @@ type column =
     static member inline isThreeFifthsFullHd = PropertyBuilders.mkClass ClassLiterals.``is-three-fifths-fullhd``
     static member inline isTwoFifthsFullHd = PropertyBuilders.mkClass ClassLiterals.``is-two-fifths-fullhd``
     static member inline isOneFifthFullHd = PropertyBuilders.mkClass ClassLiterals.``is-one-fifth-fullhd``
-    
-[<Fable.Core.Erase>]       
+
+[<Fable.Core.Erase>]
 type help =
     static member inline isPrimary = PropertyBuilders.mkClass ClassLiterals.``is-primary``
     static member inline isInfo = PropertyBuilders.mkClass ClassLiterals.``is-info``


### PR DESCRIPTION
Issue #21

@Dzoukr I ported all the adaption I had Fulma.

Like mentioned in #24 there are some tiny abstraction which has been added too for:

- `paginationLink`
- `menuItem`

In these case, I added docs comments like that:

```
/// <summary>
/// Generate &lt;li&gt;&lt;button class=&quot;pagination-link&quot;&gt;&lt;/button&gt;&lt;/li&gt;
///
/// You control the `button` element
/// </summary>
```

The tool is render correctly in the IDE, we need to do that because the docs comments are XML based so we escape the specials chars