### PR TITLE
Uses progress element for Bulma.progress

### DIFF
--- a/src/Feliz.Bulma/Bulma.fs
+++ b/src/Feliz.Bulma/Bulma.fs
@@ -297,11 +297,11 @@ type Bulma =
     static member inline notification s = ElementBuilders.Div.valueStr ElementLiterals.``notification`` s
     static member inline notification i = ElementBuilders.Div.valueInt ElementLiterals.``notification`` i
 
-    static member inline progress props = ElementBuilders.Div.props ElementLiterals.``progress`` props
-    static member inline progress (elms:#seq<ReactElement>) = ElementBuilders.Div.children ElementLiterals.``progress`` elms
-    static member inline progress elm = ElementBuilders.Div.valueElm ElementLiterals.``progress`` elm
-    static member inline progress s = ElementBuilders.Div.valueStr ElementLiterals.``progress`` s
-    static member inline progress i = ElementBuilders.Div.valueInt ElementLiterals.``progress`` i
+    static member inline progress props = ElementBuilders.Progress.props ElementLiterals.``progress`` props
+    static member inline progress (elms:#seq<ReactElement>) = ElementBuilders.Progress.children ElementLiterals.``progress`` elms
+    static member inline progress elm = ElementBuilders.Progress.valueElm ElementLiterals.``progress`` elm
+    static member inline progress s = ElementBuilders.Progress.valueStr ElementLiterals.``progress`` s
+    static member inline progress i = ElementBuilders.Progress.valueInt ElementLiterals.``progress`` i
 
     static member inline table props = ElementBuilders.Table.props ElementLiterals.``table`` props
     static member inline table (elms:#seq<ReactElement>) = ElementBuilders.Table.children ElementLiterals.``table`` elms

--- a/src/Feliz.Bulma/Modifiers.fs
+++ b/src/Feliz.Bulma/Modifiers.fs
@@ -610,6 +610,9 @@ type image =
 type progress =
     static member inline value v = PropertyBuilders.mkValue v
     static member inline max v = PropertyBuilders.mkMax v
+    static member inline isSmall = PropertyBuilders.mkClass ClassLiterals.``is-small``
+    static member inline isMedium = PropertyBuilders.mkClass ClassLiterals.``is-medium``
+    static member inline isLarge = PropertyBuilders.mkClass ClassLiterals.``is-large``
 
 [<Fable.Core.Erase>]
 type table =


### PR DESCRIPTION
`Bulma.progress` was rendereing `div` elements instead of `progress`. I also added some size modifiers to the `progress` modifier.