### PR TITLE
Reduce effect on bundle size by not inlining combineClasses

### DIFF
--- a/src/Feliz.Bulma/ElementBuilders.fs
+++ b/src/Feliz.Bulma/ElementBuilders.fs
@@ -1,26 +1,25 @@
-﻿module Feliz.Bulma.ElementBuilders
+module Feliz.Bulma.ElementBuilders
 
 open Feliz
 open Feliz.Bulma
 
-module internal Helpers =
-    let [<Literal>] ClassName = "className"
+module Helpers =
+    let [<Literal>] private ClassName = "className"
 
-    let inline getClasses (xs:IReactProperty list) =
+    let inline internal getClasses (xs:IReactProperty list) =
         xs
-        |> List.map unbox<string * obj>
-        |> List.filter (fun (v,_) -> v = ClassName)
-        |> List.map (snd >> string)
+        |> List.choose (unbox<string * obj> >> function
+            | (k, v) when k = ClassName -> Some (string v)
+            | _ -> None)
 
-    let inline partitionClasses (xs:IReactProperty list) =
+    let inline internal partitionClasses (xs:IReactProperty list) =
         xs
         |> List.partition (unbox<string * obj> >> fst >> ((=) ClassName))
 
-    let inline combineClasses cn (xs:IReactProperty list) =
+    let combineClasses cn (xs:IReactProperty list) =
         xs
         |> getClasses
-        |> List.append [cn]
-        |> fun x -> prop.classes x
+        |> fun x -> cn :: x |> prop.classes
 
 module Div =
     let inline props (cn:string) (xs:IReactProperty list) = Html.div [ yield! xs; yield Helpers.combineClasses cn xs ]


### PR DESCRIPTION
First of all, thanks for creating Feliz.Bulma! I'm currently working on a large-ish app using Feliz.Bulma and I noticed that the inlining of combineClasses leads to a significant increase in the production bundle size. Not inlining the function reduces our bundle size by ~ 50KB after minification. The downside of not inlining is that the Helpers module cannot be internal, but that's probably not that important since clients shouldn't use ElementBuilders directly anyway. Also, the changes to getClasses slightly improve performance.