### PR TITLE
Filter out className properties when combining classes to avoid React errors in development mode

### DIFF
--- a/src/Feliz.Bulma/Bulma.fs
+++ b/src/Feliz.Bulma/Bulma.fs
@@ -256,8 +256,8 @@ type Bulma =
     static member inline textarea elm = ElementBuilders.Textarea.valueElm ElementLiterals.``textarea`` elm
 
     static member inline select props =
-        let cp,nonCp = ElementBuilders.Helpers.partitionClasses props
-        Html.div [ ElementBuilders.Helpers.combineClasses ElementLiterals.``select`` cp; prop.children [ Html.select nonCp ] ]
+        let classes, props = ElementBuilders.Helpers.extractClasses props
+        Html.div [ prop.classes (ElementLiterals.``select`` :: classes); prop.children [ Html.select props ] ]
     static member inline select (elms:#seq<ReactElement>) = Html.div [ prop.className ElementLiterals.``select``; prop.children [ Html.select elms ] ]
     static member inline select (elm:ReactElement) = Html.div [ prop.className ElementLiterals.``select``; prop.children [ Html.select [ elm ] ] ]
 

--- a/src/Feliz.Bulma/ElementBuilders.fs
+++ b/src/Feliz.Bulma/ElementBuilders.fs
@@ -12,44 +12,48 @@ module Helpers =
             | (k, v) when k = ClassName -> Some (string v)
             | _ -> None)
 
-    let inline internal partitionClasses (xs:IReactProperty list) =
+    let extractClasses (xs:IReactProperty list) =
         xs
-        |> List.partition (unbox<string * obj> >> fst >> ((=) ClassName))
+        |> List.rev
+        |> List.fold (fun (classes, props) x ->
+            match unbox<string * obj> x with
+            | (k, v) when k = ClassName -> string v :: classes, props
+            | _ -> classes, x :: props) ([], [])
 
     let combineClasses cn (xs:IReactProperty list) =
         xs
-        |> getClasses
-        |> fun x -> cn :: x |> prop.classes
+        |> extractClasses
+        |> fun (classes, props) -> (cn :: classes |> prop.classes) :: props
 
 module Div =
-    let inline props (cn:string) (xs:IReactProperty list) = Html.div [ yield! xs; yield Helpers.combineClasses cn xs ]
+    let inline props (cn:string) (xs:IReactProperty list) = Html.div (Helpers.combineClasses cn xs)
     let inline children (cn:string) (children:seq<ReactElement>) = Html.div [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
     let inline valueStr (cn:string) (value:string) = Html.div [ prop.className cn; prop.text value ]
     let inline valueInt (cn:string) (value:int) = Html.div [ prop.className cn; prop.text value ]
 
 module Nav =
-    let inline props (cn:string) (xs:IReactProperty list) = Html.nav [ yield! xs; yield Helpers.combineClasses cn xs ]
+    let inline props (cn:string) (xs:IReactProperty list) = Html.nav (Helpers.combineClasses cn xs)
     let inline children (cn:string) (children:seq<ReactElement>) = Html.nav [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
 
 module Article =
-    let inline props (cn:string) (xs:IReactProperty list) = Html.article [ yield! xs; yield Helpers.combineClasses cn xs ]
+    let inline props (cn:string) (xs:IReactProperty list) = Html.article (Helpers.combineClasses cn xs)
     let inline children (cn:string) (children:seq<ReactElement>) = Html.article [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
 
 module Section =
-    let inline props (cn:string) (xs:IReactProperty list) = Html.section [ yield! xs; yield Helpers.combineClasses cn xs ]
+    let inline props (cn:string) (xs:IReactProperty list) = Html.section (Helpers.combineClasses cn xs)
     let inline children (cn:string) (children:seq<ReactElement>) = Html.section [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
 
 module Footer =
-    let inline props (cn:string) (xs:IReactProperty list) = Html.footer [ yield! xs; yield Helpers.combineClasses cn xs ]
+    let inline props (cn:string) (xs:IReactProperty list) = Html.footer (Helpers.combineClasses cn xs)
     let inline children (cn:string) (children:seq<ReactElement>) = Html.footer [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
 
 module Label =
-    let inline props (cn:string) (xs:IReactProperty list) = Html.label [ yield! xs; yield Helpers.combineClasses cn xs ]
+    let inline props (cn:string) (xs:IReactProperty list) = Html.label (Helpers.combineClasses cn xs)
     let inline children (cn:string) (children:seq<ReactElement>) = Html.label [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
     let inline valueStr (cn:string) (value:string) = Html.label [ prop.className cn; prop.text value ]
@@ -57,118 +61,118 @@ module Label =
 
 module Input =
     let inline propsWithType (cn:string) (typ: IReactProperty) (xs:IReactProperty list) =
-        Html.input [ yield! xs; typ; Helpers.combineClasses cn xs ]
+        Html.input (typ :: Helpers.combineClasses cn xs)
 
 module Textarea =
-    let inline props (cn:string) (xs:IReactProperty list) = Html.textarea [ yield! xs; yield Helpers.combineClasses cn xs ]
+    let inline props (cn:string) (xs:IReactProperty list) = Html.textarea (Helpers.combineClasses cn xs)
     let inline children (cn:string) (children:seq<ReactElement>) = Html.textarea [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
 
 module Button =
-    let inline props (cn:string) (xs:IReactProperty list) = Html.button [ yield! xs; yield Helpers.combineClasses cn xs ]
+    let inline props (cn:string) (xs:IReactProperty list) = Html.button (Helpers.combineClasses cn xs)
     let inline children (cn:string) (children:seq<ReactElement>) = Html.button [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
     let inline valueStr (cn:string) (value:string) = Html.button [ prop.className cn; prop.text value ]
     let inline valueInt (cn:string) (value:int) = Html.button [ prop.className cn; prop.text value ]
 
 module Span =
-    let inline props (cn:string) (xs:IReactProperty list) = Html.span [ yield! xs; yield Helpers.combineClasses cn xs ]
+    let inline props (cn:string) (xs:IReactProperty list) = Html.span (Helpers.combineClasses cn xs)
     let inline children (cn:string) (children:seq<ReactElement>) = Html.span [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
     let inline valueStr (cn:string) (value:string) = Html.span [ prop.className cn; prop.text value ]
     let inline valueInt (cn:string) (value:int) = Html.span [ prop.className cn; prop.text value ]
 
 module Figure =
-    let inline props (cn:string) (xs:IReactProperty list) = Html.figure [ yield! xs; yield Helpers.combineClasses cn xs ]
+    let inline props (cn:string) (xs:IReactProperty list) = Html.figure (Helpers.combineClasses cn xs)
     let inline children (cn:string) (children:seq<ReactElement>) = Html.figure [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
 
 module Progress =
-    let inline props (cn:string) (xs:IReactProperty list) = Html.progress [ yield! xs; yield Helpers.combineClasses cn xs ]
+    let inline props (cn:string) (xs:IReactProperty list) = Html.progress (Helpers.combineClasses cn xs)
     let inline children (cn:string) (children:seq<ReactElement>) = Html.progress [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
     let inline valueStr (cn:string) (value:string) = Html.progress [ prop.className cn; prop.text value ]
     let inline valueInt (cn:string) (value:int) = Html.progress [ prop.className cn; prop.text value ]
 
 module Table =
-    let inline props (cn:string) (xs:IReactProperty list) = Html.table [ yield! xs; yield Helpers.combineClasses cn xs ]
+    let inline props (cn:string) (xs:IReactProperty list) = Html.table (Helpers.combineClasses cn xs)
     let inline children (cn:string) (children:seq<ReactElement>) = Html.table [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
 
 module H1 =
-    let inline props (cn:string) (xs:IReactProperty list) = Html.h1 [ yield! xs; yield Helpers.combineClasses cn xs ]
+    let inline props (cn:string) (xs:IReactProperty list) = Html.h1 (Helpers.combineClasses cn xs)
     let inline children (cn:string) (children:seq<ReactElement>) = Html.h1 [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
     let inline valueStr (cn:string) (value:string) = Html.h1 [ prop.className cn; prop.text value ]
     let inline valueInt (cn:string) (value:int) = Html.h1 [ prop.className cn; prop.text value ]
 
 module H2 =
-    let inline props (cn:string) (xs:IReactProperty list) = Html.h2 [ yield! xs; yield Helpers.combineClasses cn xs ]
+    let inline props (cn:string) (xs:IReactProperty list) = Html.h2 (Helpers.combineClasses cn xs)
     let inline children (cn:string) (children:seq<ReactElement>) = Html.h2 [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
     let inline valueStr (cn:string) (value:string) = Html.h2 [ prop.className cn; prop.text value ]
     let inline valueInt (cn:string) (value:int) = Html.h2 [ prop.className cn; prop.text value ]
 
 module H3 =
-    let inline props (cn:string) (xs:IReactProperty list) = Html.h3 [ yield! xs; yield Helpers.combineClasses cn xs ]
+    let inline props (cn:string) (xs:IReactProperty list) = Html.h3 (Helpers.combineClasses cn xs)
     let inline children (cn:string) (children:seq<ReactElement>) = Html.h3 [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
     let inline valueStr (cn:string) (value:string) = Html.h3 [ prop.className cn; prop.text value ]
     let inline valueInt (cn:string) (value:int) = Html.h3 [ prop.className cn; prop.text value ]
 
 module H4 =
-    let inline props (cn:string) (xs:IReactProperty list) = Html.h4 [ yield! xs; yield Helpers.combineClasses cn xs ]
+    let inline props (cn:string) (xs:IReactProperty list) = Html.h4 (Helpers.combineClasses cn xs)
     let inline children (cn:string) (children:seq<ReactElement>) = Html.h4 [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
     let inline valueStr (cn:string) (value:string) = Html.h4 [ prop.className cn; prop.text value ]
     let inline valueInt (cn:string) (value:int) = Html.h4 [ prop.className cn; prop.text value ]
 
 module H5 =
-    let inline props (cn:string) (xs:IReactProperty list) = Html.h5 [ yield! xs; yield Helpers.combineClasses cn xs ]
+    let inline props (cn:string) (xs:IReactProperty list) = Html.h5 (Helpers.combineClasses cn xs)
     let inline children (cn:string) (children:seq<ReactElement>) = Html.h5 [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
     let inline valueStr (cn:string) (value:string) = Html.h5 [ prop.className cn; prop.text value ]
     let inline valueInt (cn:string) (value:int) = Html.h5 [ prop.className cn; prop.text value ]
 
 module H6 =
-    let inline props (cn:string) (xs:IReactProperty list) = Html.h6 [ yield! xs; yield Helpers.combineClasses cn xs ]
+    let inline props (cn:string) (xs:IReactProperty list) = Html.h6 (Helpers.combineClasses cn xs)
     let inline children (cn:string) (children:seq<ReactElement>) = Html.h6 [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
     let inline valueStr (cn:string) (value:string) = Html.h6 [ prop.className cn; prop.text value ]
     let inline valueInt (cn:string) (value:int) = Html.h6 [ prop.className cn; prop.text value ]
 
 module Hr =
-    let inline props (cn:string) (xs:IReactProperty list) = Html.hr [ yield! xs; yield Helpers.combineClasses cn xs ]
+    let inline props (cn:string) (xs:IReactProperty list) = Html.hr (Helpers.combineClasses cn xs)
 
 module Aside =
-    let inline props (cn:string) (xs:IReactProperty list) = Html.aside [ yield! xs; yield Helpers.combineClasses cn xs ]
+    let inline props (cn:string) (xs:IReactProperty list) = Html.aside (Helpers.combineClasses cn xs)
     let inline children (cn:string) (children:seq<ReactElement>) = Html.aside [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
 
 module P =
-    let inline props (cn:string) (xs:IReactProperty list) = Html.p [ yield! xs; yield Helpers.combineClasses cn xs ]
+    let inline props (cn:string) (xs:IReactProperty list) = Html.p (Helpers.combineClasses cn xs)
     let inline children (cn:string) (children:seq<ReactElement>) = Html.p [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
     let inline valueStr (cn:string) (value:string) = Html.p [ prop.className cn; prop.text value ]
     let inline valueInt (cn:string) (value:int) = Html.p [ prop.className cn; prop.text value ]
 
 module Ul =
-    let inline props (cn:string) (xs:IReactProperty list) = Html.ul [ yield! xs; yield Helpers.combineClasses cn xs ]
+    let inline props (cn:string) (xs:IReactProperty list) = Html.ul (Helpers.combineClasses cn xs)
     let inline children (cn:string) (children:seq<ReactElement>) = Html.ul [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
 
 module Li =
-    let inline props (cn:string) (xs:IReactProperty list) = Html.li [ yield! xs; yield Helpers.combineClasses cn xs ]
+    let inline props (cn:string) (xs:IReactProperty list) = Html.li (Helpers.combineClasses cn xs)
     let inline children (cn:string) (children:seq<ReactElement>) = Html.li [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
 
 module Header =
-    let inline props (cn:string) (xs:IReactProperty list) = Html.header [ yield! xs; yield Helpers.combineClasses cn xs ]
+    let inline props (cn:string) (xs:IReactProperty list) = Html.header (Helpers.combineClasses cn xs)
     let inline children (cn:string) (children:seq<ReactElement>) = Html.header [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
 
 module A =
-    let inline props (cn:string) (xs:IReactProperty list) = Html.a [ yield! xs; yield Helpers.combineClasses cn xs ]
+    let inline props (cn:string) (xs:IReactProperty list) = Html.a (Helpers.combineClasses cn xs)
     let inline children (cn:string) (children:seq<ReactElement>) = Html.a [ prop.className cn; prop.children children ]
     let inline valueElm (cn:string) (value:ReactElement) = value |> List.singleton |> children cn
     let inline valueStr (cn:string) (value:string) = Html.a [ prop.className cn; prop.text value ]


### PR DESCRIPTION
Fixes #49 