### PR TITLE
Allow closing the date picker on selecting new value

### DIFF
--- a/src/Docs/Views.DateTimePicker.fs
+++ b/src/Docs/Views.DateTimePicker.fs
@@ -114,6 +114,7 @@ DateTimePicker.timePicker [
     dateTimePicker.clearLabel "Smazat"
     dateTimePicker.locale DateTime.Locales.Czech
     dateTimePicker.minDate DateTime.UtcNow
+    dateTimePicker.closeOnSelect true
 ]
 """
             Bulma.subtitle.h5 "Date picker (range value)"
@@ -121,6 +122,7 @@ DateTimePicker.timePicker [
                 dateTimePicker.dateOnly true
                 dateTimePicker.onDateRangeSelected (fun (d:(DateTime * DateTime) option) -> () (* handle here *))
                 dateTimePicker.isRange true
+                dateTimePicker.closeOnSelect true
             ]
             Html.p ""
             code """DateTimePicker.dateTimePicker [
@@ -153,6 +155,7 @@ DateTimePicker.timePicker [
                 dateTimePicker.defaultValue DateTime.Today
                 dateTimePicker.onDateRangeSelected (fun (d:(DateTime * DateTime) option) -> () (* handle here *))
                 dateTimePicker.isRange false
+                dateTimePicker.closeOnSelect true
             ]
             Html.p ""
             code """DateTimePicker.dateTimePicker [
@@ -161,6 +164,7 @@ DateTimePicker.timePicker [
     dateTimePicker.defaultValue DateTime.Today
     dateTimePicker.onDateRangeSelected (fun (d:(DateTime * DateTime) option) -> () (* handle here *))
     dateTimePicker.isRange false
+    dateTimePicker.closeOnSelect true
 ]
 """
 

--- a/src/Feliz.Bulma.DateTimePicker/DateTime.fs
+++ b/src/Feliz.Bulma.DateTimePicker/DateTime.fs
@@ -27,6 +27,7 @@ module DatePicker =
         abstract minDate: DateTime option
         abstract maxDate: DateTime option
         abstract dateOnly : bool
+        abstract closeOnSelect: bool
 
     type private DateTimeValue = { Date : DateTime option; Time : TimeSpan option }
 
@@ -211,11 +212,23 @@ module DatePicker =
             EditMode.Date |> setEditMode
             d |> setCurrentMonth
 
+        let closeOnFilledDate (s:SelectedValue) =
+            match (p.closeOnSelect, p.dateOnly, p.isRange, p.displayMode) with
+            | (true, true, false, DisplayMode.Default) ->
+                setIsDisplayed false
+            | (true, true, true, DisplayMode.Default) ->
+                if s.From.Date.IsSome && s.To.Date.IsSome then
+                    setIsDisplayed false
+            | _ ->
+                ()
+            s
+
         let onDateSelected (d:DateTime) =
             if p.isRange then
                 d |> SelectedValue.applyDateSelectionOnRange value
             else
                 d |> SelectedValue.applyDateSelectionOnSingle value
+            |> closeOnFilledDate
             |> updateDate
 
         let onClear _ =
@@ -487,3 +500,5 @@ type dateTimePicker =
     static member inline minDate (v:DateTime) : IDateTimePickerProperty = unbox ("minDate", v)
     static member inline maxDate (v:DateTime) : IDateTimePickerProperty = unbox ("maxDate", v)
     static member inline dateOnly (v:bool) : IDateTimePickerProperty = unbox ("dateOnly", v)
+    /// Close the picker when the date is selected, only applicable for DatePicker
+    static member inline closeOnSelect (v:bool) : IDateTimePickerProperty = unbox ("closeOnSelect", v)


### PR DESCRIPTION
Added new setting that allows closing the date picker immediately after value is selected.