### PR TITLE
Fix selecting date written by text

### DIFF
--- a/src/Feliz.Bulma.DateTimePicker/DateTime.fs
+++ b/src/Feliz.Bulma.DateTimePicker/DateTime.fs
@@ -498,6 +498,7 @@ module DatePicker =
                             To = { Date = None ; Time = None }}
                    |> setValue
                    parsedDate |> setCurrentMonth
+                   parsedDate |> onDateSelected
                else
                    ()
             with


### PR DESCRIPTION
When user changes date in calendar, function `onDateSelected` is now called in order to inform the application about the change.